### PR TITLE
Nuevo servicio "actionsTopic"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       AUTH0_CLIENT: ${AUTH0_CLIENT}
       AUTH0_SECRET: ${AUTH0_SECRET}
     command: pnpm --filter=service-state -r start
-  actionsTopic:
+  actionstopic:
     restart: always
     image: pabloszx/learner-model-gql
     network_mode: host
@@ -69,7 +69,7 @@ services:
       AUTH0_DOMAIN: ${AUTH0_DOMAIN}
       AUTH0_CLIENT: ${AUTH0_CLIENT}
       AUTH0_SECRET: ${AUTH0_SECRET}
-    command: pnpm --filter=service-actionsTopic -r actionsTopic
+    command: pnpm --filter=service-actionstopic -r actionstopic
   gateway:
     restart: always
     image: pabloszx/learner-model-gql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       AUTH0_DOMAIN: ${AUTH0_DOMAIN}
       AUTH0_CLIENT: ${AUTH0_CLIENT}
       AUTH0_SECRET: ${AUTH0_SECRET}
-    command: pnpm --filter=service-state -r actionsTopic
+    command: pnpm --filter=service-actionsTopic -r actionsTopic
   gateway:
     restart: always
     image: pabloszx/learner-model-gql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,16 @@ services:
       AUTH0_CLIENT: ${AUTH0_CLIENT}
       AUTH0_SECRET: ${AUTH0_SECRET}
     command: pnpm --filter=service-state -r start
+  actionsTopic:
+    restart: always
+    image: pabloszx/learner-model-gql
+    network_mode: host
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
+      AUTH0_CLIENT: ${AUTH0_CLIENT}
+      AUTH0_SECRET: ${AUTH0_SECRET}
+    command: pnpm --filter=service-state -r actionsTopic
   gateway:
     restart: always
     image: pabloszx/learner-model-gql

--- a/packages/gateway/src/ez.generated.ts
+++ b/packages/gateway/src/ez.generated.ts
@@ -153,6 +153,22 @@ export type ActionVerb = {
   name: Scalars["String"];
 };
 
+export type ActionsByTopicConnection = Connection & {
+  __typename?: "ActionsByTopicConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllTopicsReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
+export type ActionsByUserConnection = Connection & {
+  __typename?: "ActionsByUserConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllActionsByUserReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
 /** Paginated Actions */
 export type ActionsConnection = Connection & {
   __typename?: "ActionsConnection";
@@ -160,6 +176,27 @@ export type ActionsConnection = Connection & {
   nodes: Array<Action>;
   /** Pagination related information */
   pageInfo: PageInfo;
+};
+
+export type ActionsTopicInput = {
+  projectId: Scalars["Int"];
+  topicsIds: Scalars["Int"];
+};
+
+export type ActionsTopicQueries = {
+  __typename?: "ActionsTopicQueries";
+  allActionsByTopic: ActionsByTopicConnection;
+  allActionsByUser: ActionsByUserConnection;
+};
+
+export type ActionsTopicQueriesallActionsByTopicArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
+};
+
+export type ActionsTopicQueriesallActionsByUserArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
 };
 
 /** Paginated Actions Verbs */
@@ -637,6 +674,32 @@ export type AdminUsersFilter = {
   tags?: InputMaybe<Array<Scalars["String"]>>;
   /** Filter by text search inside "email", "name", "tags" or "projects" */
   textSearch?: InputMaybe<Scalars["String"]>;
+};
+
+export type AllActionsByContentReturn = {
+  __typename?: "AllActionsByContentReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<KC>;
+};
+
+export type AllActionsByUserReturn = {
+  __typename?: "AllActionsByUserReturn";
+  actions: Array<Action>;
+  email: Scalars["String"];
+  id: Scalars["IntID"];
+  modelStates: Scalars["JSON"];
+};
+
+export type AllTopicsReturn = {
+  __typename?: "AllTopicsReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<KC>;
 };
 
 /** Pagination Interface */
@@ -1433,6 +1496,8 @@ export type ProjectsConnection = Connection & {
 
 export type Query = {
   __typename?: "Query";
+  /** ActionsTopic Query */
+  actionsTopic: ActionsTopicQueries;
   /** Admin related actions queries, only authenticated users with the role "ADMIN" can access */
   adminActions: AdminActionQueries;
   /** Admin related content queries, only authenticated users with the role "ADMIN" can access */
@@ -1970,7 +2035,12 @@ export type ResolversTypes = {
   ID: ResolverTypeWrapper<Scalars["ID"]>;
   ActionInput: ActionInput;
   ActionVerb: ResolverTypeWrapper<ActionVerb>;
+  ActionsByTopicConnection: ResolverTypeWrapper<ActionsByTopicConnection>;
+  ActionsByUserConnection: ResolverTypeWrapper<ActionsByUserConnection>;
   ActionsConnection: ResolverTypeWrapper<ActionsConnection>;
+  ActionsTopicInput: ActionsTopicInput;
+  Int: ResolverTypeWrapper<Scalars["Int"]>;
+  ActionsTopicQueries: ResolverTypeWrapper<ActionsTopicQueries>;
   ActionsVerbsConnection: ResolverTypeWrapper<ActionsVerbsConnection>;
   AdminActionQueries: ResolverTypeWrapper<AdminActionQueries>;
   AdminActionsFilter: AdminActionsFilter;
@@ -1990,7 +2060,12 @@ export type ResolversTypes = {
   AdminUserMutations: ResolverTypeWrapper<AdminUserMutations>;
   AdminUserQueries: ResolverTypeWrapper<AdminUserQueries>;
   AdminUsersFilter: AdminUsersFilter;
+  AllActionsByContentReturn: ResolverTypeWrapper<AllActionsByContentReturn>;
+  AllActionsByUserReturn: ResolverTypeWrapper<AllActionsByUserReturn>;
+  AllTopicsReturn: ResolverTypeWrapper<AllTopicsReturn>;
   Connection:
+    | ResolversTypes["ActionsByTopicConnection"]
+    | ResolversTypes["ActionsByUserConnection"]
     | ResolversTypes["ActionsConnection"]
     | ResolversTypes["ActionsVerbsConnection"]
     | ResolversTypes["ContentConnection"]
@@ -2004,7 +2079,6 @@ export type ResolversTypes = {
     | ResolversTypes["TopicsConnection"]
     | ResolversTypes["UsersConnection"];
   Content: ResolverTypeWrapper<Content>;
-  Int: ResolverTypeWrapper<Scalars["Int"]>;
   ContentConnection: ResolverTypeWrapper<ContentConnection>;
   ContentSelectedPropsReturn: ResolverTypeWrapper<ContentSelectedPropsReturn>;
   ContentSelectionInput: ContentSelectionInput;
@@ -2084,7 +2158,12 @@ export type ResolversParentTypes = {
   ID: Scalars["ID"];
   ActionInput: ActionInput;
   ActionVerb: ActionVerb;
+  ActionsByTopicConnection: ActionsByTopicConnection;
+  ActionsByUserConnection: ActionsByUserConnection;
   ActionsConnection: ActionsConnection;
+  ActionsTopicInput: ActionsTopicInput;
+  Int: Scalars["Int"];
+  ActionsTopicQueries: ActionsTopicQueries;
   ActionsVerbsConnection: ActionsVerbsConnection;
   AdminActionQueries: AdminActionQueries;
   AdminActionsFilter: AdminActionsFilter;
@@ -2104,7 +2183,12 @@ export type ResolversParentTypes = {
   AdminUserMutations: AdminUserMutations;
   AdminUserQueries: AdminUserQueries;
   AdminUsersFilter: AdminUsersFilter;
+  AllActionsByContentReturn: AllActionsByContentReturn;
+  AllActionsByUserReturn: AllActionsByUserReturn;
+  AllTopicsReturn: AllTopicsReturn;
   Connection:
+    | ResolversParentTypes["ActionsByTopicConnection"]
+    | ResolversParentTypes["ActionsByUserConnection"]
     | ResolversParentTypes["ActionsConnection"]
     | ResolversParentTypes["ActionsVerbsConnection"]
     | ResolversParentTypes["ContentConnection"]
@@ -2118,7 +2202,6 @@ export type ResolversParentTypes = {
     | ResolversParentTypes["TopicsConnection"]
     | ResolversParentTypes["UsersConnection"];
   Content: Content;
-  Int: Scalars["Int"];
   ContentConnection: ContentConnection;
   ContentSelectedPropsReturn: ContentSelectedPropsReturn;
   ContentSelectionInput: ContentSelectionInput;
@@ -2220,12 +2303,63 @@ export type ActionVerbResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ActionsByTopicConnectionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ActionsByTopicConnection"] = ResolversParentTypes["ActionsByTopicConnection"]
+> = {
+  nodes?: Resolver<
+    Array<ResolversTypes["AllTopicsReturn"]>,
+    ParentType,
+    ContextType
+  >;
+  pageInfo?: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ActionsByUserConnectionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ActionsByUserConnection"] = ResolversParentTypes["ActionsByUserConnection"]
+> = {
+  nodes?: Resolver<
+    Array<ResolversTypes["AllActionsByUserReturn"]>,
+    ParentType,
+    ContextType
+  >;
+  pageInfo?: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ActionsConnectionResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["ActionsConnection"] = ResolversParentTypes["ActionsConnection"]
 > = {
   nodes?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
   pageInfo?: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ActionsTopicQueriesResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ActionsTopicQueries"] = ResolversParentTypes["ActionsTopicQueries"]
+> = {
+  allActionsByTopic?: Resolver<
+    ResolversTypes["ActionsByTopicConnection"],
+    ParentType,
+    ContextType,
+    RequireFields<
+      ActionsTopicQueriesallActionsByTopicArgs,
+      "input" | "pagination"
+    >
+  >;
+  allActionsByUser?: Resolver<
+    ResolversTypes["ActionsByUserConnection"],
+    ParentType,
+    ContextType,
+    RequireFields<
+      ActionsTopicQueriesallActionsByUserArgs,
+      "input" | "pagination"
+    >
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2507,11 +2641,48 @@ export type AdminUserQueriesResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type AllActionsByContentReturnResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["AllActionsByContentReturn"] = ResolversParentTypes["AllActionsByContentReturn"]
+> = {
+  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  json?: Resolver<ResolversTypes["JSONObject"], ParentType, ContextType>;
+  kcs?: Resolver<Array<ResolversTypes["KC"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AllActionsByUserReturnResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["AllActionsByUserReturn"] = ResolversParentTypes["AllActionsByUserReturn"]
+> = {
+  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  email?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  modelStates?: Resolver<ResolversTypes["JSON"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AllTopicsReturnResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["AllTopicsReturn"] = ResolversParentTypes["AllTopicsReturn"]
+> = {
+  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  json?: Resolver<ResolversTypes["JSONObject"], ParentType, ContextType>;
+  kcs?: Resolver<Array<ResolversTypes["KC"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ConnectionResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["Connection"] = ResolversParentTypes["Connection"]
 > = {
   __resolveType: TypeResolveFn<
+    | "ActionsByTopicConnection"
+    | "ActionsByUserConnection"
     | "ActionsConnection"
     | "ActionsVerbsConnection"
     | "ContentConnection"
@@ -2992,6 +3163,11 @@ export type QueryResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["Query"] = ResolversParentTypes["Query"]
 > = {
+  actionsTopic?: Resolver<
+    ResolversTypes["ActionsTopicQueries"],
+    ParentType,
+    ContextType
+  >;
   adminActions?: Resolver<
     ResolversTypes["AdminActionQueries"],
     ParentType,
@@ -3230,7 +3406,10 @@ export interface VoidScalarConfig
 export type Resolvers<ContextType = EZContext> = {
   Action?: ActionResolvers<ContextType>;
   ActionVerb?: ActionVerbResolvers<ContextType>;
+  ActionsByTopicConnection?: ActionsByTopicConnectionResolvers<ContextType>;
+  ActionsByUserConnection?: ActionsByUserConnectionResolvers<ContextType>;
   ActionsConnection?: ActionsConnectionResolvers<ContextType>;
+  ActionsTopicQueries?: ActionsTopicQueriesResolvers<ContextType>;
   ActionsVerbsConnection?: ActionsVerbsConnectionResolvers<ContextType>;
   AdminActionQueries?: AdminActionQueriesResolvers<ContextType>;
   AdminContentMutations?: AdminContentMutationsResolvers<ContextType>;
@@ -3242,6 +3421,9 @@ export type Resolvers<ContextType = EZContext> = {
   AdminStateQueries?: AdminStateQueriesResolvers<ContextType>;
   AdminUserMutations?: AdminUserMutationsResolvers<ContextType>;
   AdminUserQueries?: AdminUserQueriesResolvers<ContextType>;
+  AllActionsByContentReturn?: AllActionsByContentReturnResolvers<ContextType>;
+  AllActionsByUserReturn?: AllActionsByUserReturnResolvers<ContextType>;
+  AllTopicsReturn?: AllTopicsReturnResolvers<ContextType>;
   Connection?: ConnectionResolvers<ContextType>;
   Content?: ContentResolvers<ContextType>;
   ContentConnection?: ContentConnectionResolvers<ContextType>;

--- a/packages/gateway/src/ez.generated.ts
+++ b/packages/gateway/src/ez.generated.ts
@@ -180,7 +180,7 @@ export type ActionsConnection = Connection & {
 
 export type ActionsTopicInput = {
   projectId: Scalars["Int"];
-  topicsIds: Scalars["Int"];
+  topicsIds: Array<Scalars["Int"]>;
 };
 
 export type ActionsTopicQueries = {
@@ -688,6 +688,7 @@ export type AllActionsByContentReturn = {
 export type AllActionsByUserReturn = {
   __typename?: "AllActionsByUserReturn";
   actions: Array<Action>;
+  createdAt: Scalars["DateTime"];
   email: Scalars["String"];
   id: Scalars["IntID"];
   modelStates: Scalars["JSON"];
@@ -2658,6 +2659,7 @@ export type AllActionsByUserReturnResolvers<
   ParentType extends ResolversParentTypes["AllActionsByUserReturn"] = ResolversParentTypes["AllActionsByUserReturn"]
 > = {
   actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   email?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
   modelStates?: Resolver<ResolversTypes["JSON"], ParentType, ContextType>;

--- a/packages/gateway/src/ez.generated.ts
+++ b/packages/gateway/src/ez.generated.ts
@@ -181,8 +181,16 @@ export type ActionsConnection = Connection & {
 };
 
 export type ActionsTopicInput = {
+  /** End interval for conducting the search. */
+  endDate: Scalars["DateTime"];
+  /** ID of the project. */
   projectId: Scalars["Int"];
+  /** Start interval for conducting the search. */
+  startDate: Scalars["DateTime"];
+  /** Array of topic IDs where the search will be performed. */
   topicsIds: Array<Scalars["Int"]>;
+  /** Array of verbs to be used for action search. */
+  verbNames: Array<Scalars["String"]>;
 };
 
 export type ActionsTopicQueries = {

--- a/packages/gateway/src/ez.generated.ts
+++ b/packages/gateway/src/ez.generated.ts
@@ -153,18 +153,20 @@ export type ActionVerb = {
   name: Scalars["String"];
 };
 
-export type ActionsByTopicConnection = Connection & {
-  __typename?: "ActionsByTopicConnection";
+/** Paginated ActionsByContent */
+export type ActionsByContentConnection = Connection & {
+  __typename?: "ActionsByContentConnection";
   /** Nodes of the current page */
-  nodes: Array<AllTopicsReturn>;
+  nodes: Array<AllActionsByContent>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
 
+/** Paginated ActionsByUser */
 export type ActionsByUserConnection = Connection & {
   __typename?: "ActionsByUserConnection";
   /** Nodes of the current page */
-  nodes: Array<AllActionsByUserReturn>;
+  nodes: Array<AllActionsByUser>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
@@ -185,11 +187,21 @@ export type ActionsTopicInput = {
 
 export type ActionsTopicQueries = {
   __typename?: "ActionsTopicQueries";
-  allActionsByTopic: ActionsByTopicConnection;
+  /**
+   * Returns all actions performed, grouped by Content.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
+  allActionsByContent: ActionsByContentConnection;
+  /**
+   * Returns all actions performed, grouped by users.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
   allActionsByUser: ActionsByUserConnection;
 };
 
-export type ActionsTopicQueriesallActionsByTopicArgs = {
+export type ActionsTopicQueriesallActionsByContentArgs = {
   input: ActionsTopicInput;
   pagination: CursorConnectionArgs;
 };
@@ -676,31 +688,32 @@ export type AdminUsersFilter = {
   textSearch?: InputMaybe<Scalars["String"]>;
 };
 
-export type AllActionsByContentReturn = {
-  __typename?: "AllActionsByContentReturn";
+export type AllActionsByContent = {
+  __typename?: "AllActionsByContent";
+  /** Actions performed on the content. */
   actions: Array<Action>;
+  /** Unique string identifier */
   code: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Arbitrary JSON object data */
   json: Scalars["JSONObject"];
+  /** KCs associated with the content */
   kcs: Array<KC>;
 };
 
-export type AllActionsByUserReturn = {
-  __typename?: "AllActionsByUserReturn";
+export type AllActionsByUser = {
+  __typename?: "AllActionsByUser";
+  /** Actions performed by user */
   actions: Array<Action>;
+  /** Date of creation */
   createdAt: Scalars["DateTime"];
+  /** Email Address */
   email: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Model States associated with user */
   modelStates: Scalars["JSON"];
-};
-
-export type AllTopicsReturn = {
-  __typename?: "AllTopicsReturn";
-  actions: Array<Action>;
-  code: Scalars["String"];
-  id: Scalars["IntID"];
-  json: Scalars["JSONObject"];
-  kcs: Array<KC>;
 };
 
 /** Pagination Interface */
@@ -1497,7 +1510,10 @@ export type ProjectsConnection = Connection & {
 
 export type Query = {
   __typename?: "Query";
-  /** ActionsTopic Query */
+  /**
+   * This service retrieves all actions performed on the specified topics through the input.
+   * These actions are grouped by user and content.
+   */
   actionsTopic: ActionsTopicQueries;
   /** Admin related actions queries, only authenticated users with the role "ADMIN" can access */
   adminActions: AdminActionQueries;
@@ -2036,7 +2052,7 @@ export type ResolversTypes = {
   ID: ResolverTypeWrapper<Scalars["ID"]>;
   ActionInput: ActionInput;
   ActionVerb: ResolverTypeWrapper<ActionVerb>;
-  ActionsByTopicConnection: ResolverTypeWrapper<ActionsByTopicConnection>;
+  ActionsByContentConnection: ResolverTypeWrapper<ActionsByContentConnection>;
   ActionsByUserConnection: ResolverTypeWrapper<ActionsByUserConnection>;
   ActionsConnection: ResolverTypeWrapper<ActionsConnection>;
   ActionsTopicInput: ActionsTopicInput;
@@ -2061,11 +2077,10 @@ export type ResolversTypes = {
   AdminUserMutations: ResolverTypeWrapper<AdminUserMutations>;
   AdminUserQueries: ResolverTypeWrapper<AdminUserQueries>;
   AdminUsersFilter: AdminUsersFilter;
-  AllActionsByContentReturn: ResolverTypeWrapper<AllActionsByContentReturn>;
-  AllActionsByUserReturn: ResolverTypeWrapper<AllActionsByUserReturn>;
-  AllTopicsReturn: ResolverTypeWrapper<AllTopicsReturn>;
+  AllActionsByContent: ResolverTypeWrapper<AllActionsByContent>;
+  AllActionsByUser: ResolverTypeWrapper<AllActionsByUser>;
   Connection:
-    | ResolversTypes["ActionsByTopicConnection"]
+    | ResolversTypes["ActionsByContentConnection"]
     | ResolversTypes["ActionsByUserConnection"]
     | ResolversTypes["ActionsConnection"]
     | ResolversTypes["ActionsVerbsConnection"]
@@ -2159,7 +2174,7 @@ export type ResolversParentTypes = {
   ID: Scalars["ID"];
   ActionInput: ActionInput;
   ActionVerb: ActionVerb;
-  ActionsByTopicConnection: ActionsByTopicConnection;
+  ActionsByContentConnection: ActionsByContentConnection;
   ActionsByUserConnection: ActionsByUserConnection;
   ActionsConnection: ActionsConnection;
   ActionsTopicInput: ActionsTopicInput;
@@ -2184,11 +2199,10 @@ export type ResolversParentTypes = {
   AdminUserMutations: AdminUserMutations;
   AdminUserQueries: AdminUserQueries;
   AdminUsersFilter: AdminUsersFilter;
-  AllActionsByContentReturn: AllActionsByContentReturn;
-  AllActionsByUserReturn: AllActionsByUserReturn;
-  AllTopicsReturn: AllTopicsReturn;
+  AllActionsByContent: AllActionsByContent;
+  AllActionsByUser: AllActionsByUser;
   Connection:
-    | ResolversParentTypes["ActionsByTopicConnection"]
+    | ResolversParentTypes["ActionsByContentConnection"]
     | ResolversParentTypes["ActionsByUserConnection"]
     | ResolversParentTypes["ActionsConnection"]
     | ResolversParentTypes["ActionsVerbsConnection"]
@@ -2304,12 +2318,12 @@ export type ActionVerbResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ActionsByTopicConnectionResolvers<
+export type ActionsByContentConnectionResolvers<
   ContextType = EZContext,
-  ParentType extends ResolversParentTypes["ActionsByTopicConnection"] = ResolversParentTypes["ActionsByTopicConnection"]
+  ParentType extends ResolversParentTypes["ActionsByContentConnection"] = ResolversParentTypes["ActionsByContentConnection"]
 > = {
   nodes?: Resolver<
-    Array<ResolversTypes["AllTopicsReturn"]>,
+    Array<ResolversTypes["AllActionsByContent"]>,
     ParentType,
     ContextType
   >;
@@ -2322,7 +2336,7 @@ export type ActionsByUserConnectionResolvers<
   ParentType extends ResolversParentTypes["ActionsByUserConnection"] = ResolversParentTypes["ActionsByUserConnection"]
 > = {
   nodes?: Resolver<
-    Array<ResolversTypes["AllActionsByUserReturn"]>,
+    Array<ResolversTypes["AllActionsByUser"]>,
     ParentType,
     ContextType
   >;
@@ -2343,12 +2357,12 @@ export type ActionsTopicQueriesResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["ActionsTopicQueries"] = ResolversParentTypes["ActionsTopicQueries"]
 > = {
-  allActionsByTopic?: Resolver<
-    ResolversTypes["ActionsByTopicConnection"],
+  allActionsByContent?: Resolver<
+    ResolversTypes["ActionsByContentConnection"],
     ParentType,
     ContextType,
     RequireFields<
-      ActionsTopicQueriesallActionsByTopicArgs,
+      ActionsTopicQueriesallActionsByContentArgs,
       "input" | "pagination"
     >
   >;
@@ -2642,9 +2656,9 @@ export type AdminUserQueriesResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type AllActionsByContentReturnResolvers<
+export type AllActionsByContentResolvers<
   ContextType = EZContext,
-  ParentType extends ResolversParentTypes["AllActionsByContentReturn"] = ResolversParentTypes["AllActionsByContentReturn"]
+  ParentType extends ResolversParentTypes["AllActionsByContent"] = ResolversParentTypes["AllActionsByContent"]
 > = {
   actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
   code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
@@ -2654,9 +2668,9 @@ export type AllActionsByContentReturnResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type AllActionsByUserReturnResolvers<
+export type AllActionsByUserResolvers<
   ContextType = EZContext,
-  ParentType extends ResolversParentTypes["AllActionsByUserReturn"] = ResolversParentTypes["AllActionsByUserReturn"]
+  ParentType extends ResolversParentTypes["AllActionsByUser"] = ResolversParentTypes["AllActionsByUser"]
 > = {
   actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
@@ -2666,24 +2680,12 @@ export type AllActionsByUserReturnResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type AllTopicsReturnResolvers<
-  ContextType = EZContext,
-  ParentType extends ResolversParentTypes["AllTopicsReturn"] = ResolversParentTypes["AllTopicsReturn"]
-> = {
-  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
-  code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
-  json?: Resolver<ResolversTypes["JSONObject"], ParentType, ContextType>;
-  kcs?: Resolver<Array<ResolversTypes["KC"]>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
 export type ConnectionResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["Connection"] = ResolversParentTypes["Connection"]
 > = {
   __resolveType: TypeResolveFn<
-    | "ActionsByTopicConnection"
+    | "ActionsByContentConnection"
     | "ActionsByUserConnection"
     | "ActionsConnection"
     | "ActionsVerbsConnection"
@@ -3408,7 +3410,7 @@ export interface VoidScalarConfig
 export type Resolvers<ContextType = EZContext> = {
   Action?: ActionResolvers<ContextType>;
   ActionVerb?: ActionVerbResolvers<ContextType>;
-  ActionsByTopicConnection?: ActionsByTopicConnectionResolvers<ContextType>;
+  ActionsByContentConnection?: ActionsByContentConnectionResolvers<ContextType>;
   ActionsByUserConnection?: ActionsByUserConnectionResolvers<ContextType>;
   ActionsConnection?: ActionsConnectionResolvers<ContextType>;
   ActionsTopicQueries?: ActionsTopicQueriesResolvers<ContextType>;
@@ -3423,9 +3425,8 @@ export type Resolvers<ContextType = EZContext> = {
   AdminStateQueries?: AdminStateQueriesResolvers<ContextType>;
   AdminUserMutations?: AdminUserMutationsResolvers<ContextType>;
   AdminUserQueries?: AdminUserQueriesResolvers<ContextType>;
-  AllActionsByContentReturn?: AllActionsByContentReturnResolvers<ContextType>;
-  AllActionsByUserReturn?: AllActionsByUserReturnResolvers<ContextType>;
-  AllTopicsReturn?: AllTopicsReturnResolvers<ContextType>;
+  AllActionsByContent?: AllActionsByContentResolvers<ContextType>;
+  AllActionsByUser?: AllActionsByUserResolvers<ContextType>;
   Connection?: ConnectionResolvers<ContextType>;
   Content?: ContentResolvers<ContextType>;
   ContentConnection?: ContentConnectionResolvers<ContextType>;

--- a/packages/graph/src/rq-gql/graphql.ts
+++ b/packages/graph/src/rq-gql/graphql.ts
@@ -166,8 +166,16 @@ export type ActionsConnection = Connection & {
 };
 
 export type ActionsTopicInput = {
+  /** End interval for conducting the search. */
+  endDate: Scalars["DateTime"];
+  /** ID of the project. */
   projectId: Scalars["Int"];
+  /** Start interval for conducting the search. */
+  startDate: Scalars["DateTime"];
+  /** Array of topic IDs where the search will be performed. */
   topicsIds: Array<Scalars["Int"]>;
+  /** Array of verbs to be used for action search. */
+  verbNames: Array<Scalars["String"]>;
 };
 
 export type ActionsTopicQueries = {

--- a/packages/graph/src/rq-gql/graphql.ts
+++ b/packages/graph/src/rq-gql/graphql.ts
@@ -138,6 +138,22 @@ export type ActionVerb = {
   name: Scalars["String"];
 };
 
+export type ActionsByTopicConnection = Connection & {
+  __typename?: "ActionsByTopicConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllTopicsReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
+export type ActionsByUserConnection = Connection & {
+  __typename?: "ActionsByUserConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllActionsByUserReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
 /** Paginated Actions */
 export type ActionsConnection = Connection & {
   __typename?: "ActionsConnection";
@@ -145,6 +161,27 @@ export type ActionsConnection = Connection & {
   nodes: Array<Action>;
   /** Pagination related information */
   pageInfo: PageInfo;
+};
+
+export type ActionsTopicInput = {
+  projectId: Scalars["Int"];
+  topicsIds: Scalars["Int"];
+};
+
+export type ActionsTopicQueries = {
+  __typename?: "ActionsTopicQueries";
+  allActionsByTopic: ActionsByTopicConnection;
+  allActionsByUser: ActionsByUserConnection;
+};
+
+export type ActionsTopicQueriesAllActionsByTopicArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
+};
+
+export type ActionsTopicQueriesAllActionsByUserArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
 };
 
 /** Paginated Actions Verbs */
@@ -622,6 +659,32 @@ export type AdminUsersFilter = {
   tags?: InputMaybe<Array<Scalars["String"]>>;
   /** Filter by text search inside "email", "name", "tags" or "projects" */
   textSearch?: InputMaybe<Scalars["String"]>;
+};
+
+export type AllActionsByContentReturn = {
+  __typename?: "AllActionsByContentReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<Kc>;
+};
+
+export type AllActionsByUserReturn = {
+  __typename?: "AllActionsByUserReturn";
+  actions: Array<Action>;
+  email: Scalars["String"];
+  id: Scalars["IntID"];
+  modelStates: Scalars["JSON"];
+};
+
+export type AllTopicsReturn = {
+  __typename?: "AllTopicsReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<Kc>;
 };
 
 /** Pagination Interface */
@@ -1418,6 +1481,8 @@ export type ProjectsConnection = Connection & {
 
 export type Query = {
   __typename?: "Query";
+  /** ActionsTopic Query */
+  actionsTopic: ActionsTopicQueries;
   /** Admin related actions queries, only authenticated users with the role "ADMIN" can access */
   adminActions: AdminActionQueries;
   /** Admin related content queries, only authenticated users with the role "ADMIN" can access */
@@ -1997,6 +2062,28 @@ export type AllKCsBaseQuery = {
   };
 };
 
+type Pagination_ActionsByTopicConnection_Fragment = {
+  __typename?: "ActionsByTopicConnection";
+  pageInfo: {
+    __typename?: "PageInfo";
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor?: string | null;
+    endCursor?: string | null;
+  };
+};
+
+type Pagination_ActionsByUserConnection_Fragment = {
+  __typename?: "ActionsByUserConnection";
+  pageInfo: {
+    __typename?: "PageInfo";
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor?: string | null;
+    endCursor?: string | null;
+  };
+};
+
 type Pagination_ActionsConnection_Fragment = {
   __typename?: "ActionsConnection";
   pageInfo: {
@@ -2130,6 +2217,8 @@ type Pagination_UsersConnection_Fragment = {
 };
 
 export type PaginationFragment =
+  | Pagination_ActionsByTopicConnection_Fragment
+  | Pagination_ActionsByUserConnection_Fragment
   | Pagination_ActionsConnection_Fragment
   | Pagination_ActionsVerbsConnection_Fragment
   | Pagination_ContentConnection_Fragment

--- a/packages/graph/src/rq-gql/graphql.ts
+++ b/packages/graph/src/rq-gql/graphql.ts
@@ -138,18 +138,20 @@ export type ActionVerb = {
   name: Scalars["String"];
 };
 
-export type ActionsByTopicConnection = Connection & {
-  __typename?: "ActionsByTopicConnection";
+/** Paginated ActionsByContent */
+export type ActionsByContentConnection = Connection & {
+  __typename?: "ActionsByContentConnection";
   /** Nodes of the current page */
-  nodes: Array<AllTopicsReturn>;
+  nodes: Array<AllActionsByContent>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
 
+/** Paginated ActionsByUser */
 export type ActionsByUserConnection = Connection & {
   __typename?: "ActionsByUserConnection";
   /** Nodes of the current page */
-  nodes: Array<AllActionsByUserReturn>;
+  nodes: Array<AllActionsByUser>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
@@ -170,11 +172,21 @@ export type ActionsTopicInput = {
 
 export type ActionsTopicQueries = {
   __typename?: "ActionsTopicQueries";
-  allActionsByTopic: ActionsByTopicConnection;
+  /**
+   * Returns all actions performed, grouped by Content.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
+  allActionsByContent: ActionsByContentConnection;
+  /**
+   * Returns all actions performed, grouped by users.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
   allActionsByUser: ActionsByUserConnection;
 };
 
-export type ActionsTopicQueriesAllActionsByTopicArgs = {
+export type ActionsTopicQueriesAllActionsByContentArgs = {
   input: ActionsTopicInput;
   pagination: CursorConnectionArgs;
 };
@@ -661,31 +673,32 @@ export type AdminUsersFilter = {
   textSearch?: InputMaybe<Scalars["String"]>;
 };
 
-export type AllActionsByContentReturn = {
-  __typename?: "AllActionsByContentReturn";
+export type AllActionsByContent = {
+  __typename?: "AllActionsByContent";
+  /** Actions performed on the content. */
   actions: Array<Action>;
+  /** Unique string identifier */
   code: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Arbitrary JSON object data */
   json: Scalars["JSONObject"];
+  /** KCs associated with the content */
   kcs: Array<Kc>;
 };
 
-export type AllActionsByUserReturn = {
-  __typename?: "AllActionsByUserReturn";
+export type AllActionsByUser = {
+  __typename?: "AllActionsByUser";
+  /** Actions performed by user */
   actions: Array<Action>;
+  /** Date of creation */
   createdAt: Scalars["DateTime"];
+  /** Email Address */
   email: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Model States associated with user */
   modelStates: Scalars["JSON"];
-};
-
-export type AllTopicsReturn = {
-  __typename?: "AllTopicsReturn";
-  actions: Array<Action>;
-  code: Scalars["String"];
-  id: Scalars["IntID"];
-  json: Scalars["JSONObject"];
-  kcs: Array<Kc>;
 };
 
 /** Pagination Interface */
@@ -1482,7 +1495,10 @@ export type ProjectsConnection = Connection & {
 
 export type Query = {
   __typename?: "Query";
-  /** ActionsTopic Query */
+  /**
+   * This service retrieves all actions performed on the specified topics through the input.
+   * These actions are grouped by user and content.
+   */
   actionsTopic: ActionsTopicQueries;
   /** Admin related actions queries, only authenticated users with the role "ADMIN" can access */
   adminActions: AdminActionQueries;
@@ -2063,8 +2079,8 @@ export type AllKCsBaseQuery = {
   };
 };
 
-type Pagination_ActionsByTopicConnection_Fragment = {
-  __typename?: "ActionsByTopicConnection";
+type Pagination_ActionsByContentConnection_Fragment = {
+  __typename?: "ActionsByContentConnection";
   pageInfo: {
     __typename?: "PageInfo";
     hasNextPage: boolean;
@@ -2218,7 +2234,7 @@ type Pagination_UsersConnection_Fragment = {
 };
 
 export type PaginationFragment =
-  | Pagination_ActionsByTopicConnection_Fragment
+  | Pagination_ActionsByContentConnection_Fragment
   | Pagination_ActionsByUserConnection_Fragment
   | Pagination_ActionsConnection_Fragment
   | Pagination_ActionsVerbsConnection_Fragment

--- a/packages/graph/src/rq-gql/graphql.ts
+++ b/packages/graph/src/rq-gql/graphql.ts
@@ -165,7 +165,7 @@ export type ActionsConnection = Connection & {
 
 export type ActionsTopicInput = {
   projectId: Scalars["Int"];
-  topicsIds: Scalars["Int"];
+  topicsIds: Array<Scalars["Int"]>;
 };
 
 export type ActionsTopicQueries = {
@@ -673,6 +673,7 @@ export type AllActionsByContentReturn = {
 export type AllActionsByUserReturn = {
   __typename?: "AllActionsByUserReturn";
   actions: Array<Action>;
+  createdAt: Scalars["DateTime"];
   email: Scalars["String"];
   id: Scalars["IntID"];
   modelStates: Scalars["JSON"];

--- a/packages/mono/src/schema.ts
+++ b/packages/mono/src/schema.ts
@@ -43,6 +43,7 @@ export const subSchemas = [
     "contentSelection",
     GetSchema(import("../../services/contentSelection/src/app")),
   ],
+  ["actionstopic", GetSchema(import("../../services/actionsTopic/src/app"))],
 ] as const;
 
 export const schema = lexicographicSortSchema(

--- a/packages/services/actionsTopic/package.json
+++ b/packages/services/actionsTopic/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "service-actionsTopic",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "bob-tsm --node-env=dev --watch=src src/index.ts",
+    "start": "bob-tsm src/index.ts"
+  },
+  "dependencies": {
+    "api-base": "workspace:^0.0.1",
+    "db": "workspace:^0.0.1"
+  }
+}

--- a/packages/services/actionsTopic/package.json
+++ b/packages/services/actionsTopic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "service-actionsTopic",
+  "name": "service-actionstopic",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/packages/services/actionsTopic/schema.gql
+++ b/packages/services/actionsTopic/schema.gql
@@ -59,8 +59,16 @@ type ActionsByUserConnection implements Connection {
 }
 
 input ActionsTopicInput {
+  "End interval for conducting the search."
+  endDate: DateTime!
+  "ID of the project."
   projectId: Int!
+  "Start interval for conducting the search."
+  startDate: DateTime!
+  "Array of topic IDs where the search will be performed."
   topicsIds: [Int!]!
+  "Array of verbs to be used for action search."
+  verbNames: [String!]!
 }
 
 type ActionsTopicQueries {

--- a/packages/services/actionsTopic/schema.gql
+++ b/packages/services/actionsTopic/schema.gql
@@ -58,7 +58,7 @@ type ActionsByUserConnection implements Connection {
 
 input ActionsTopicInput {
   projectId: Int!
-  topicsIds: Int!
+  topicsIds: [Int!]!
 }
 
 type ActionsTopicQueries {
@@ -82,6 +82,7 @@ type AllActionsByContentReturn {
 
 type AllActionsByUserReturn {
   actions: [Action!]!
+  createdAt: DateTime!
   email: String!
   id: IntID!
   modelStates: JSON!

--- a/packages/services/actionsTopic/schema.gql
+++ b/packages/services/actionsTopic/schema.gql
@@ -42,16 +42,18 @@ type ActionVerb {
   name: String!
 }
 
-type ActionsByTopicConnection implements Connection {
+"Paginated ActionsByContent"
+type ActionsByContentConnection implements Connection {
   "Nodes of the current page"
-  nodes: [AllTopicsReturn!]!
+  nodes: [AllActionsByContent!]!
   "Pagination related information"
   pageInfo: PageInfo!
 }
 
+"Paginated ActionsByUser"
 type ActionsByUserConnection implements Connection {
   "Nodes of the current page"
-  nodes: [AllActionsByUserReturn!]!
+  nodes: [AllActionsByUser!]!
   "Pagination related information"
   pageInfo: PageInfo!
 }
@@ -62,38 +64,50 @@ input ActionsTopicInput {
 }
 
 type ActionsTopicQueries {
-  allActionsByTopic(
+  """
+  Returns all actions performed, grouped by Content.
+  Pagination parameters are used to control the number of returned results,
+  making this parameter mandatory.
+  """
+  allActionsByContent(
     input: ActionsTopicInput!
     pagination: CursorConnectionArgs!
-  ): ActionsByTopicConnection!
+  ): ActionsByContentConnection!
+  """
+  Returns all actions performed, grouped by users.
+  Pagination parameters are used to control the number of returned results,
+  making this parameter mandatory.
+  """
   allActionsByUser(
     input: ActionsTopicInput!
     pagination: CursorConnectionArgs!
   ): ActionsByUserConnection!
 }
 
-type AllActionsByContentReturn {
+type AllActionsByContent {
+  "Actions performed on the content."
   actions: [Action!]!
+  "Unique string identifier"
   code: String!
+  "Unique numeric identifier"
   id: IntID!
+  "Arbitrary JSON object data"
   json: JSONObject!
+  "KCs associated with the content"
   kcs: [KC!]!
 }
 
-type AllActionsByUserReturn {
+type AllActionsByUser {
+  "Actions performed by user"
   actions: [Action!]!
+  "Date of creation"
   createdAt: DateTime!
+  "Email Address"
   email: String!
+  "Unique numeric identifier"
   id: IntID!
+  "Model States associated with user"
   modelStates: JSON!
-}
-
-type AllTopicsReturn {
-  actions: [Action!]!
-  code: String!
-  id: IntID!
-  json: JSONObject!
-  kcs: [KC!]!
 }
 
 "Pagination Interface"
@@ -219,7 +233,10 @@ type PageInfo {
 }
 
 type Query {
-  "ActionsTopic Query"
+  """
+  This service retrieves all actions performed on the specified topics through the input.
+  These actions are grouped by user and content.
+  """
   actionsTopic: ActionsTopicQueries!
   "Returns 'Hello World!'"
   hello: String!

--- a/packages/services/actionsTopic/schema.gql
+++ b/packages/services/actionsTopic/schema.gql
@@ -1,0 +1,257 @@
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+type Action {
+  "Arbitrary numeric amount"
+  amount: Float
+  "Related content"
+  content: Content
+  "Timestamp of the action, set by the database on row creation"
+  createdAt: DateTime!
+  "Arbitrary string content detail"
+  detail: String
+  "Arbitrary JSON object data"
+  extra: JSONObject
+  "Arbitrary hint identifier"
+  hintID: ID
+  "Unique numeric identifier"
+  id: IntID!
+  "Related KCs"
+  kcs: [KC!]!
+  "Arbitrary numeric result"
+  result: Float
+  "Arbitrary step identifier"
+  stepID: ID
+  "Timestamp of the action, set by the action emitter"
+  timestamp: Timestamp!
+  "Related topic"
+  topic: Topic
+  "User that emitted the action"
+  user: User
+  "Type of action"
+  verb: ActionVerb!
+}
+
+type ActionVerb {
+  "Unique numeric identifier"
+  id: IntID!
+  "Name of the verb"
+  name: String!
+}
+
+type ActionsByTopicConnection implements Connection {
+  "Nodes of the current page"
+  nodes: [AllTopicsReturn!]!
+  "Pagination related information"
+  pageInfo: PageInfo!
+}
+
+type ActionsByUserConnection implements Connection {
+  "Nodes of the current page"
+  nodes: [AllActionsByUserReturn!]!
+  "Pagination related information"
+  pageInfo: PageInfo!
+}
+
+input ActionsTopicInput {
+  projectId: Int!
+  topicsIds: Int!
+}
+
+type ActionsTopicQueries {
+  allActionsByTopic(
+    input: ActionsTopicInput!
+    pagination: CursorConnectionArgs!
+  ): ActionsByTopicConnection!
+  allActionsByUser(
+    input: ActionsTopicInput!
+    pagination: CursorConnectionArgs!
+  ): ActionsByUserConnection!
+}
+
+type AllActionsByContentReturn {
+  actions: [Action!]!
+  code: String!
+  id: IntID!
+  json: JSONObject!
+  kcs: [KC!]!
+}
+
+type AllActionsByUserReturn {
+  actions: [Action!]!
+  email: String!
+  id: IntID!
+  modelStates: JSON!
+}
+
+type AllTopicsReturn {
+  actions: [Action!]!
+  code: String!
+  id: IntID!
+  json: JSONObject!
+  kcs: [KC!]!
+}
+
+"Pagination Interface"
+interface Connection {
+  "Pagination information"
+  pageInfo: PageInfo!
+}
+
+"Content entity"
+type Content {
+  "Unique numeric identifier"
+  id: IntID!
+}
+
+"""
+Pagination parameters
+
+Forward pagination parameters can't be mixed with Backward pagination parameters simultaneously
+
+first & after => Forward Pagination
+
+last & before => Backward Pagination
+"""
+input CursorConnectionArgs {
+  """
+  Set the minimum boundary
+
+  Use the "endCursor" field of "pageInfo"
+  """
+  after: IntID
+  """
+  Set the maximum boundary
+
+  Use the "startCursor" field of "pageInfo"
+  """
+  before: IntID
+  """
+  Set the limit of nodes to be fetched
+
+  It can't be more than 50
+  """
+  first: NonNegativeInt
+  """
+  Set the limit of nodes to be fetched
+
+  It can't be more than 50
+  """
+  last: NonNegativeInt
+}
+
+"""
+A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+"""
+scalar DateTime
+
+"""
+A field whose value conforms to the standard internet email address format as specified in RFC822: https://www.w3.org/Protocols/rfc822/.
+"""
+scalar EmailAddress @specifiedBy(url: "https://www.w3.org/Protocols/rfc822/")
+
+"""
+ID that parses as non-negative integer, serializes to string, and can be passed as string or number
+"""
+scalar IntID
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
+
+type KC {
+  "Unique numeric identifier"
+  id: IntID!
+}
+
+type Mutation {
+  "Returns 'Hello World!'"
+  hello: String!
+}
+
+"Minimum Entity Information"
+interface Node {
+  "Unique numeric identifier"
+  id: IntID!
+}
+
+"""
+Integers that will have a value of 0 or more.
+"""
+scalar NonNegativeInt
+
+"Order ascendingly or descendingly"
+enum ORDER_BY {
+  ASC
+  DESC
+}
+
+"Paginated related information"
+type PageInfo {
+  "Cursor parameter normally used for forward pagination"
+  endCursor: String
+  """
+  Utility field that returns "true" if a next page can be fetched
+  """
+  hasNextPage: Boolean!
+  """
+  Utility field that returns "true" if a previous page can be fetched
+  """
+  hasPreviousPage: Boolean!
+  "Cursor parameter normally used for backward pagination"
+  startCursor: String
+}
+
+type Query {
+  "ActionsTopic Query"
+  actionsTopic: ActionsTopicQueries!
+  "Returns 'Hello World!'"
+  hello: String!
+}
+
+type Subscription {
+  "Emits 'Hello World1', 'Hello World2', 'Hello World3', 'Hello World4' and 'Hello World5'"
+  hello: String!
+}
+
+"""
+The javascript `Date` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch.
+"""
+scalar Timestamp
+
+"Topic entity"
+type Topic {
+  "Unique numeric identifier"
+  id: IntID!
+}
+
+"""
+A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt.
+"""
+scalar URL
+
+"User entity"
+type User {
+  "Unique numeric identifier"
+  id: IntID!
+}
+
+"""
+Represents NULL values
+"""
+scalar Void

--- a/packages/services/actionsTopic/src/app.ts
+++ b/packages/services/actionsTopic/src/app.ts
@@ -1,0 +1,8 @@
+import { buildApp } from "./ez";
+
+export const ezApp = buildApp({
+  async prepare() {
+    await import("./modules/index");
+  },
+});
+export * from "./ez";

--- a/packages/services/actionsTopic/src/ez.generated.ts
+++ b/packages/services/actionsTopic/src/ez.generated.ts
@@ -111,7 +111,7 @@ export type ActionsByUserConnection = Connection & {
 
 export type ActionsTopicInput = {
   projectId: Scalars["Int"];
-  topicsIds: Scalars["Int"];
+  topicsIds: Array<Scalars["Int"]>;
 };
 
 export type ActionsTopicQueries = {
@@ -142,6 +142,7 @@ export type AllActionsByContentReturn = {
 export type AllActionsByUserReturn = {
   __typename?: "AllActionsByUserReturn";
   actions: Array<Action>;
+  createdAt: Scalars["DateTime"];
   email: Scalars["String"];
   id: Scalars["IntID"];
   modelStates: Scalars["JSON"];
@@ -552,6 +553,7 @@ export type AllActionsByUserReturnResolvers<
   ParentType extends ResolversParentTypes["AllActionsByUserReturn"] = ResolversParentTypes["AllActionsByUserReturn"]
 > = {
   actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   email?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
   modelStates?: Resolver<ResolversTypes["JSON"], ParentType, ContextType>;

--- a/packages/services/actionsTopic/src/ez.generated.ts
+++ b/packages/services/actionsTopic/src/ez.generated.ts
@@ -112,8 +112,16 @@ export type ActionsByUserConnection = Connection & {
 };
 
 export type ActionsTopicInput = {
+  /** End interval for conducting the search. */
+  endDate: Scalars["DateTime"];
+  /** ID of the project. */
   projectId: Scalars["Int"];
+  /** Start interval for conducting the search. */
+  startDate: Scalars["DateTime"];
+  /** Array of topic IDs where the search will be performed. */
   topicsIds: Array<Scalars["Int"]>;
+  /** Array of verbs to be used for action search. */
+  verbNames: Array<Scalars["String"]>;
 };
 
 export type ActionsTopicQueries = {

--- a/packages/services/actionsTopic/src/ez.generated.ts
+++ b/packages/services/actionsTopic/src/ez.generated.ts
@@ -93,18 +93,20 @@ export type ActionVerb = {
   name: Scalars["String"];
 };
 
-export type ActionsByTopicConnection = Connection & {
-  __typename?: "ActionsByTopicConnection";
+/** Paginated ActionsByContent */
+export type ActionsByContentConnection = Connection & {
+  __typename?: "ActionsByContentConnection";
   /** Nodes of the current page */
-  nodes: Array<AllTopicsReturn>;
+  nodes: Array<AllActionsByContent>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
 
+/** Paginated ActionsByUser */
 export type ActionsByUserConnection = Connection & {
   __typename?: "ActionsByUserConnection";
   /** Nodes of the current page */
-  nodes: Array<AllActionsByUserReturn>;
+  nodes: Array<AllActionsByUser>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
@@ -116,11 +118,21 @@ export type ActionsTopicInput = {
 
 export type ActionsTopicQueries = {
   __typename?: "ActionsTopicQueries";
-  allActionsByTopic: ActionsByTopicConnection;
+  /**
+   * Returns all actions performed, grouped by Content.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
+  allActionsByContent: ActionsByContentConnection;
+  /**
+   * Returns all actions performed, grouped by users.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
   allActionsByUser: ActionsByUserConnection;
 };
 
-export type ActionsTopicQueriesallActionsByTopicArgs = {
+export type ActionsTopicQueriesallActionsByContentArgs = {
   input: ActionsTopicInput;
   pagination: CursorConnectionArgs;
 };
@@ -130,31 +142,32 @@ export type ActionsTopicQueriesallActionsByUserArgs = {
   pagination: CursorConnectionArgs;
 };
 
-export type AllActionsByContentReturn = {
-  __typename?: "AllActionsByContentReturn";
+export type AllActionsByContent = {
+  __typename?: "AllActionsByContent";
+  /** Actions performed on the content. */
   actions: Array<Action>;
+  /** Unique string identifier */
   code: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Arbitrary JSON object data */
   json: Scalars["JSONObject"];
+  /** KCs associated with the content */
   kcs: Array<KC>;
 };
 
-export type AllActionsByUserReturn = {
-  __typename?: "AllActionsByUserReturn";
+export type AllActionsByUser = {
+  __typename?: "AllActionsByUser";
+  /** Actions performed by user */
   actions: Array<Action>;
+  /** Date of creation */
   createdAt: Scalars["DateTime"];
+  /** Email Address */
   email: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Model States associated with user */
   modelStates: Scalars["JSON"];
-};
-
-export type AllTopicsReturn = {
-  __typename?: "AllTopicsReturn";
-  actions: Array<Action>;
-  code: Scalars["String"];
-  id: Scalars["IntID"];
-  json: Scalars["JSONObject"];
-  kcs: Array<KC>;
 };
 
 /** Pagination Interface */
@@ -246,7 +259,10 @@ export type PageInfo = {
 
 export type Query = {
   __typename?: "Query";
-  /** ActionsTopic Query */
+  /**
+   * This service retrieves all actions performed on the specified topics through the input.
+   * These actions are grouped by user and content.
+   */
   actionsTopic: ActionsTopicQueries;
   /** Returns 'Hello World!' */
   hello: Scalars["String"];
@@ -377,16 +393,15 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars["String"]>;
   ID: ResolverTypeWrapper<Scalars["ID"]>;
   ActionVerb: ResolverTypeWrapper<ActionVerb>;
-  ActionsByTopicConnection: ResolverTypeWrapper<ActionsByTopicConnection>;
+  ActionsByContentConnection: ResolverTypeWrapper<ActionsByContentConnection>;
   ActionsByUserConnection: ResolverTypeWrapper<ActionsByUserConnection>;
   ActionsTopicInput: ActionsTopicInput;
   Int: ResolverTypeWrapper<Scalars["Int"]>;
   ActionsTopicQueries: ResolverTypeWrapper<ActionsTopicQueries>;
-  AllActionsByContentReturn: ResolverTypeWrapper<AllActionsByContentReturn>;
-  AllActionsByUserReturn: ResolverTypeWrapper<AllActionsByUserReturn>;
-  AllTopicsReturn: ResolverTypeWrapper<AllTopicsReturn>;
+  AllActionsByContent: ResolverTypeWrapper<AllActionsByContent>;
+  AllActionsByUser: ResolverTypeWrapper<AllActionsByUser>;
   Connection:
-    | ResolversTypes["ActionsByTopicConnection"]
+    | ResolversTypes["ActionsByContentConnection"]
     | ResolversTypes["ActionsByUserConnection"];
   Content: ResolverTypeWrapper<Content>;
   CursorConnectionArgs: CursorConnectionArgs;
@@ -418,16 +433,15 @@ export type ResolversParentTypes = {
   String: Scalars["String"];
   ID: Scalars["ID"];
   ActionVerb: ActionVerb;
-  ActionsByTopicConnection: ActionsByTopicConnection;
+  ActionsByContentConnection: ActionsByContentConnection;
   ActionsByUserConnection: ActionsByUserConnection;
   ActionsTopicInput: ActionsTopicInput;
   Int: Scalars["Int"];
   ActionsTopicQueries: ActionsTopicQueries;
-  AllActionsByContentReturn: AllActionsByContentReturn;
-  AllActionsByUserReturn: AllActionsByUserReturn;
-  AllTopicsReturn: AllTopicsReturn;
+  AllActionsByContent: AllActionsByContent;
+  AllActionsByUser: AllActionsByUser;
   Connection:
-    | ResolversParentTypes["ActionsByTopicConnection"]
+    | ResolversParentTypes["ActionsByContentConnection"]
     | ResolversParentTypes["ActionsByUserConnection"];
   Content: Content;
   CursorConnectionArgs: CursorConnectionArgs;
@@ -485,12 +499,12 @@ export type ActionVerbResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ActionsByTopicConnectionResolvers<
+export type ActionsByContentConnectionResolvers<
   ContextType = EZContext,
-  ParentType extends ResolversParentTypes["ActionsByTopicConnection"] = ResolversParentTypes["ActionsByTopicConnection"]
+  ParentType extends ResolversParentTypes["ActionsByContentConnection"] = ResolversParentTypes["ActionsByContentConnection"]
 > = {
   nodes?: Resolver<
-    Array<ResolversTypes["AllTopicsReturn"]>,
+    Array<ResolversTypes["AllActionsByContent"]>,
     ParentType,
     ContextType
   >;
@@ -503,7 +517,7 @@ export type ActionsByUserConnectionResolvers<
   ParentType extends ResolversParentTypes["ActionsByUserConnection"] = ResolversParentTypes["ActionsByUserConnection"]
 > = {
   nodes?: Resolver<
-    Array<ResolversTypes["AllActionsByUserReturn"]>,
+    Array<ResolversTypes["AllActionsByUser"]>,
     ParentType,
     ContextType
   >;
@@ -515,12 +529,12 @@ export type ActionsTopicQueriesResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["ActionsTopicQueries"] = ResolversParentTypes["ActionsTopicQueries"]
 > = {
-  allActionsByTopic?: Resolver<
-    ResolversTypes["ActionsByTopicConnection"],
+  allActionsByContent?: Resolver<
+    ResolversTypes["ActionsByContentConnection"],
     ParentType,
     ContextType,
     RequireFields<
-      ActionsTopicQueriesallActionsByTopicArgs,
+      ActionsTopicQueriesallActionsByContentArgs,
       "input" | "pagination"
     >
   >;
@@ -536,9 +550,9 @@ export type ActionsTopicQueriesResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type AllActionsByContentReturnResolvers<
+export type AllActionsByContentResolvers<
   ContextType = EZContext,
-  ParentType extends ResolversParentTypes["AllActionsByContentReturn"] = ResolversParentTypes["AllActionsByContentReturn"]
+  ParentType extends ResolversParentTypes["AllActionsByContent"] = ResolversParentTypes["AllActionsByContent"]
 > = {
   actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
   code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
@@ -548,9 +562,9 @@ export type AllActionsByContentReturnResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type AllActionsByUserReturnResolvers<
+export type AllActionsByUserResolvers<
   ContextType = EZContext,
-  ParentType extends ResolversParentTypes["AllActionsByUserReturn"] = ResolversParentTypes["AllActionsByUserReturn"]
+  ParentType extends ResolversParentTypes["AllActionsByUser"] = ResolversParentTypes["AllActionsByUser"]
 > = {
   actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
@@ -560,24 +574,12 @@ export type AllActionsByUserReturnResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type AllTopicsReturnResolvers<
-  ContextType = EZContext,
-  ParentType extends ResolversParentTypes["AllTopicsReturn"] = ResolversParentTypes["AllTopicsReturn"]
-> = {
-  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
-  code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
-  json?: Resolver<ResolversTypes["JSONObject"], ParentType, ContextType>;
-  kcs?: Resolver<Array<ResolversTypes["KC"]>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
 export type ConnectionResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["Connection"] = ResolversParentTypes["Connection"]
 > = {
   __resolveType: TypeResolveFn<
-    "ActionsByTopicConnection" | "ActionsByUserConnection",
+    "ActionsByContentConnection" | "ActionsByUserConnection",
     ParentType,
     ContextType
   >;
@@ -726,12 +728,11 @@ export interface VoidScalarConfig
 export type Resolvers<ContextType = EZContext> = {
   Action?: ActionResolvers<ContextType>;
   ActionVerb?: ActionVerbResolvers<ContextType>;
-  ActionsByTopicConnection?: ActionsByTopicConnectionResolvers<ContextType>;
+  ActionsByContentConnection?: ActionsByContentConnectionResolvers<ContextType>;
   ActionsByUserConnection?: ActionsByUserConnectionResolvers<ContextType>;
   ActionsTopicQueries?: ActionsTopicQueriesResolvers<ContextType>;
-  AllActionsByContentReturn?: AllActionsByContentReturnResolvers<ContextType>;
-  AllActionsByUserReturn?: AllActionsByUserReturnResolvers<ContextType>;
-  AllTopicsReturn?: AllTopicsReturnResolvers<ContextType>;
+  AllActionsByContent?: AllActionsByContentResolvers<ContextType>;
+  AllActionsByUser?: AllActionsByUserResolvers<ContextType>;
   Connection?: ConnectionResolvers<ContextType>;
   Content?: ContentResolvers<ContextType>;
   DateTime?: GraphQLScalarType;

--- a/packages/services/actionsTopic/src/ez.generated.ts
+++ b/packages/services/actionsTopic/src/ez.generated.ts
@@ -1,0 +1,756 @@
+import type {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from "graphql";
+import type { EZContext } from "graphql-ez";
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) =>
+  | Promise<import("graphql-ez").DeepPartial<TResult>>
+  | import("graphql-ez").DeepPartial<TResult>;
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>;
+};
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string | number;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
+  DateTime: string | Date;
+  /** A field whose value conforms to the standard internet email address format as specified in RFC822: https://www.w3.org/Protocols/rfc822/. */
+  EmailAddress: string;
+  /** ID that parses as non-negative integer, serializes to string, and can be passed as string or number */
+  IntID: number;
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSON: unknown;
+  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSONObject: any;
+  /** Integers that will have a value of 0 or more. */
+  NonNegativeInt: number;
+  /** The javascript `Date` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch. */
+  Timestamp: Date;
+  /** A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt. */
+  URL: string;
+  /** Represents NULL values */
+  Void: unknown;
+};
+
+export type Action = {
+  __typename?: "Action";
+  /** Arbitrary numeric amount */
+  amount?: Maybe<Scalars["Float"]>;
+  /** Related content */
+  content?: Maybe<Content>;
+  /** Timestamp of the action, set by the database on row creation */
+  createdAt: Scalars["DateTime"];
+  /** Arbitrary string content detail */
+  detail?: Maybe<Scalars["String"]>;
+  /** Arbitrary JSON object data */
+  extra?: Maybe<Scalars["JSONObject"]>;
+  /** Arbitrary hint identifier */
+  hintID?: Maybe<Scalars["ID"]>;
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+  /** Related KCs */
+  kcs: Array<KC>;
+  /** Arbitrary numeric result */
+  result?: Maybe<Scalars["Float"]>;
+  /** Arbitrary step identifier */
+  stepID?: Maybe<Scalars["ID"]>;
+  /** Timestamp of the action, set by the action emitter */
+  timestamp: Scalars["Timestamp"];
+  /** Related topic */
+  topic?: Maybe<Topic>;
+  /** User that emitted the action */
+  user?: Maybe<User>;
+  /** Type of action */
+  verb: ActionVerb;
+};
+
+export type ActionVerb = {
+  __typename?: "ActionVerb";
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+  /** Name of the verb */
+  name: Scalars["String"];
+};
+
+export type ActionsByTopicConnection = Connection & {
+  __typename?: "ActionsByTopicConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllTopicsReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
+export type ActionsByUserConnection = Connection & {
+  __typename?: "ActionsByUserConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllActionsByUserReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
+export type ActionsTopicInput = {
+  projectId: Scalars["Int"];
+  topicsIds: Scalars["Int"];
+};
+
+export type ActionsTopicQueries = {
+  __typename?: "ActionsTopicQueries";
+  allActionsByTopic: ActionsByTopicConnection;
+  allActionsByUser: ActionsByUserConnection;
+};
+
+export type ActionsTopicQueriesallActionsByTopicArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
+};
+
+export type ActionsTopicQueriesallActionsByUserArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
+};
+
+export type AllActionsByContentReturn = {
+  __typename?: "AllActionsByContentReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<KC>;
+};
+
+export type AllActionsByUserReturn = {
+  __typename?: "AllActionsByUserReturn";
+  actions: Array<Action>;
+  email: Scalars["String"];
+  id: Scalars["IntID"];
+  modelStates: Scalars["JSON"];
+};
+
+export type AllTopicsReturn = {
+  __typename?: "AllTopicsReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<KC>;
+};
+
+/** Pagination Interface */
+export type Connection = {
+  /** Pagination information */
+  pageInfo: PageInfo;
+};
+
+/** Content entity */
+export type Content = {
+  __typename?: "Content";
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+};
+
+/**
+ * Pagination parameters
+ *
+ * Forward pagination parameters can't be mixed with Backward pagination parameters simultaneously
+ *
+ * first & after => Forward Pagination
+ *
+ * last & before => Backward Pagination
+ */
+export type CursorConnectionArgs = {
+  /**
+   * Set the minimum boundary
+   *
+   * Use the "endCursor" field of "pageInfo"
+   */
+  after?: InputMaybe<Scalars["IntID"]>;
+  /**
+   * Set the maximum boundary
+   *
+   * Use the "startCursor" field of "pageInfo"
+   */
+  before?: InputMaybe<Scalars["IntID"]>;
+  /**
+   * Set the limit of nodes to be fetched
+   *
+   * It can't be more than 50
+   */
+  first?: InputMaybe<Scalars["NonNegativeInt"]>;
+  /**
+   * Set the limit of nodes to be fetched
+   *
+   * It can't be more than 50
+   */
+  last?: InputMaybe<Scalars["NonNegativeInt"]>;
+};
+
+export type KC = {
+  __typename?: "KC";
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+};
+
+export type Mutation = {
+  __typename?: "Mutation";
+  /** Returns 'Hello World!' */
+  hello: Scalars["String"];
+};
+
+/** Minimum Entity Information */
+export type Node = {
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+};
+
+/** Order ascendingly or descendingly */
+export const ORDER_BY = {
+  ASC: "ASC",
+  DESC: "DESC",
+} as const;
+
+export type ORDER_BY = (typeof ORDER_BY)[keyof typeof ORDER_BY];
+/** Paginated related information */
+export type PageInfo = {
+  __typename?: "PageInfo";
+  /** Cursor parameter normally used for forward pagination */
+  endCursor?: Maybe<Scalars["String"]>;
+  /** Utility field that returns "true" if a next page can be fetched */
+  hasNextPage: Scalars["Boolean"];
+  /** Utility field that returns "true" if a previous page can be fetched */
+  hasPreviousPage: Scalars["Boolean"];
+  /** Cursor parameter normally used for backward pagination */
+  startCursor?: Maybe<Scalars["String"]>;
+};
+
+export type Query = {
+  __typename?: "Query";
+  /** ActionsTopic Query */
+  actionsTopic: ActionsTopicQueries;
+  /** Returns 'Hello World!' */
+  hello: Scalars["String"];
+};
+
+export type Subscription = {
+  __typename?: "Subscription";
+  /** Emits 'Hello World1', 'Hello World2', 'Hello World3', 'Hello World4' and 'Hello World5' */
+  hello: Scalars["String"];
+};
+
+/** Topic entity */
+export type Topic = {
+  __typename?: "Topic";
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+};
+
+/** User entity */
+export type User = {
+  __typename?: "User";
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+};
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Action: ResolverTypeWrapper<Action>;
+  Float: ResolverTypeWrapper<Scalars["Float"]>;
+  String: ResolverTypeWrapper<Scalars["String"]>;
+  ID: ResolverTypeWrapper<Scalars["ID"]>;
+  ActionVerb: ResolverTypeWrapper<ActionVerb>;
+  ActionsByTopicConnection: ResolverTypeWrapper<ActionsByTopicConnection>;
+  ActionsByUserConnection: ResolverTypeWrapper<ActionsByUserConnection>;
+  ActionsTopicInput: ActionsTopicInput;
+  Int: ResolverTypeWrapper<Scalars["Int"]>;
+  ActionsTopicQueries: ResolverTypeWrapper<ActionsTopicQueries>;
+  AllActionsByContentReturn: ResolverTypeWrapper<AllActionsByContentReturn>;
+  AllActionsByUserReturn: ResolverTypeWrapper<AllActionsByUserReturn>;
+  AllTopicsReturn: ResolverTypeWrapper<AllTopicsReturn>;
+  Connection:
+    | ResolversTypes["ActionsByTopicConnection"]
+    | ResolversTypes["ActionsByUserConnection"];
+  Content: ResolverTypeWrapper<Content>;
+  CursorConnectionArgs: CursorConnectionArgs;
+  DateTime: ResolverTypeWrapper<Scalars["DateTime"]>;
+  EmailAddress: ResolverTypeWrapper<Scalars["EmailAddress"]>;
+  IntID: ResolverTypeWrapper<Scalars["IntID"]>;
+  JSON: ResolverTypeWrapper<Scalars["JSON"]>;
+  JSONObject: ResolverTypeWrapper<Scalars["JSONObject"]>;
+  KC: ResolverTypeWrapper<KC>;
+  Mutation: ResolverTypeWrapper<{}>;
+  Node: never;
+  NonNegativeInt: ResolverTypeWrapper<Scalars["NonNegativeInt"]>;
+  ORDER_BY: ORDER_BY;
+  PageInfo: ResolverTypeWrapper<PageInfo>;
+  Boolean: ResolverTypeWrapper<Scalars["Boolean"]>;
+  Query: ResolverTypeWrapper<{}>;
+  Subscription: ResolverTypeWrapper<{}>;
+  Timestamp: ResolverTypeWrapper<Scalars["Timestamp"]>;
+  Topic: ResolverTypeWrapper<Topic>;
+  URL: ResolverTypeWrapper<Scalars["URL"]>;
+  User: ResolverTypeWrapper<User>;
+  Void: ResolverTypeWrapper<Scalars["Void"]>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Action: Action;
+  Float: Scalars["Float"];
+  String: Scalars["String"];
+  ID: Scalars["ID"];
+  ActionVerb: ActionVerb;
+  ActionsByTopicConnection: ActionsByTopicConnection;
+  ActionsByUserConnection: ActionsByUserConnection;
+  ActionsTopicInput: ActionsTopicInput;
+  Int: Scalars["Int"];
+  ActionsTopicQueries: ActionsTopicQueries;
+  AllActionsByContentReturn: AllActionsByContentReturn;
+  AllActionsByUserReturn: AllActionsByUserReturn;
+  AllTopicsReturn: AllTopicsReturn;
+  Connection:
+    | ResolversParentTypes["ActionsByTopicConnection"]
+    | ResolversParentTypes["ActionsByUserConnection"];
+  Content: Content;
+  CursorConnectionArgs: CursorConnectionArgs;
+  DateTime: Scalars["DateTime"];
+  EmailAddress: Scalars["EmailAddress"];
+  IntID: Scalars["IntID"];
+  JSON: Scalars["JSON"];
+  JSONObject: Scalars["JSONObject"];
+  KC: KC;
+  Mutation: {};
+  Node: never;
+  NonNegativeInt: Scalars["NonNegativeInt"];
+  PageInfo: PageInfo;
+  Boolean: Scalars["Boolean"];
+  Query: {};
+  Subscription: {};
+  Timestamp: Scalars["Timestamp"];
+  Topic: Topic;
+  URL: Scalars["URL"];
+  User: User;
+  Void: Scalars["Void"];
+};
+
+export type ActionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Action"] = ResolversParentTypes["Action"]
+> = {
+  amount?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
+  content?: Resolver<Maybe<ResolversTypes["Content"]>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  detail?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  extra?: Resolver<
+    Maybe<ResolversTypes["JSONObject"]>,
+    ParentType,
+    ContextType
+  >;
+  hintID?: Resolver<Maybe<ResolversTypes["ID"]>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  kcs?: Resolver<Array<ResolversTypes["KC"]>, ParentType, ContextType>;
+  result?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
+  stepID?: Resolver<Maybe<ResolversTypes["ID"]>, ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes["Timestamp"], ParentType, ContextType>;
+  topic?: Resolver<Maybe<ResolversTypes["Topic"]>, ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes["User"]>, ParentType, ContextType>;
+  verb?: Resolver<ResolversTypes["ActionVerb"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ActionVerbResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ActionVerb"] = ResolversParentTypes["ActionVerb"]
+> = {
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ActionsByTopicConnectionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ActionsByTopicConnection"] = ResolversParentTypes["ActionsByTopicConnection"]
+> = {
+  nodes?: Resolver<
+    Array<ResolversTypes["AllTopicsReturn"]>,
+    ParentType,
+    ContextType
+  >;
+  pageInfo?: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ActionsByUserConnectionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ActionsByUserConnection"] = ResolversParentTypes["ActionsByUserConnection"]
+> = {
+  nodes?: Resolver<
+    Array<ResolversTypes["AllActionsByUserReturn"]>,
+    ParentType,
+    ContextType
+  >;
+  pageInfo?: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ActionsTopicQueriesResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ActionsTopicQueries"] = ResolversParentTypes["ActionsTopicQueries"]
+> = {
+  allActionsByTopic?: Resolver<
+    ResolversTypes["ActionsByTopicConnection"],
+    ParentType,
+    ContextType,
+    RequireFields<
+      ActionsTopicQueriesallActionsByTopicArgs,
+      "input" | "pagination"
+    >
+  >;
+  allActionsByUser?: Resolver<
+    ResolversTypes["ActionsByUserConnection"],
+    ParentType,
+    ContextType,
+    RequireFields<
+      ActionsTopicQueriesallActionsByUserArgs,
+      "input" | "pagination"
+    >
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AllActionsByContentReturnResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["AllActionsByContentReturn"] = ResolversParentTypes["AllActionsByContentReturn"]
+> = {
+  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  json?: Resolver<ResolversTypes["JSONObject"], ParentType, ContextType>;
+  kcs?: Resolver<Array<ResolversTypes["KC"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AllActionsByUserReturnResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["AllActionsByUserReturn"] = ResolversParentTypes["AllActionsByUserReturn"]
+> = {
+  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  email?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  modelStates?: Resolver<ResolversTypes["JSON"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AllTopicsReturnResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["AllTopicsReturn"] = ResolversParentTypes["AllTopicsReturn"]
+> = {
+  actions?: Resolver<Array<ResolversTypes["Action"]>, ParentType, ContextType>;
+  code?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  json?: Resolver<ResolversTypes["JSONObject"], ParentType, ContextType>;
+  kcs?: Resolver<Array<ResolversTypes["KC"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ConnectionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Connection"] = ResolversParentTypes["Connection"]
+> = {
+  __resolveType: TypeResolveFn<
+    "ActionsByTopicConnection" | "ActionsByUserConnection",
+    ParentType,
+    ContextType
+  >;
+  pageInfo?: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+};
+
+export type ContentResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Content"] = ResolversParentTypes["Content"]
+> = {
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export interface DateTimeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["DateTime"], any> {
+  name: "DateTime";
+}
+
+export interface EmailAddressScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["EmailAddress"], any> {
+  name: "EmailAddress";
+}
+
+export interface IntIDScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["IntID"], any> {
+  name: "IntID";
+}
+
+export interface JSONScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["JSON"], any> {
+  name: "JSON";
+}
+
+export interface JSONObjectScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["JSONObject"], any> {
+  name: "JSONObject";
+}
+
+export type KCResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["KC"] = ResolversParentTypes["KC"]
+> = {
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type MutationResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Mutation"] = ResolversParentTypes["Mutation"]
+> = {
+  hello?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+};
+
+export type NodeResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Node"] = ResolversParentTypes["Node"]
+> = {
+  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+};
+
+export interface NonNegativeIntScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["NonNegativeInt"], any> {
+  name: "NonNegativeInt";
+}
+
+export type PageInfoResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["PageInfo"] = ResolversParentTypes["PageInfo"]
+> = {
+  endCursor?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  hasNextPage?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  hasPreviousPage?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  startCursor?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type QueryResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Query"] = ResolversParentTypes["Query"]
+> = {
+  actionsTopic?: Resolver<
+    ResolversTypes["ActionsTopicQueries"],
+    ParentType,
+    ContextType
+  >;
+  hello?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+};
+
+export type SubscriptionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Subscription"] = ResolversParentTypes["Subscription"]
+> = {
+  hello?: SubscriptionResolver<
+    ResolversTypes["String"],
+    "hello",
+    ParentType,
+    ContextType
+  >;
+};
+
+export interface TimestampScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["Timestamp"], any> {
+  name: "Timestamp";
+}
+
+export type TopicResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Topic"] = ResolversParentTypes["Topic"]
+> = {
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export interface URLScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["URL"], any> {
+  name: "URL";
+}
+
+export type UserResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["User"] = ResolversParentTypes["User"]
+> = {
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export interface VoidScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["Void"], any> {
+  name: "Void";
+}
+
+export type Resolvers<ContextType = EZContext> = {
+  Action?: ActionResolvers<ContextType>;
+  ActionVerb?: ActionVerbResolvers<ContextType>;
+  ActionsByTopicConnection?: ActionsByTopicConnectionResolvers<ContextType>;
+  ActionsByUserConnection?: ActionsByUserConnectionResolvers<ContextType>;
+  ActionsTopicQueries?: ActionsTopicQueriesResolvers<ContextType>;
+  AllActionsByContentReturn?: AllActionsByContentReturnResolvers<ContextType>;
+  AllActionsByUserReturn?: AllActionsByUserReturnResolvers<ContextType>;
+  AllTopicsReturn?: AllTopicsReturnResolvers<ContextType>;
+  Connection?: ConnectionResolvers<ContextType>;
+  Content?: ContentResolvers<ContextType>;
+  DateTime?: GraphQLScalarType;
+  EmailAddress?: GraphQLScalarType;
+  IntID?: GraphQLScalarType;
+  JSON?: GraphQLScalarType;
+  JSONObject?: GraphQLScalarType;
+  KC?: KCResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
+  Node?: NodeResolvers<ContextType>;
+  NonNegativeInt?: GraphQLScalarType;
+  PageInfo?: PageInfoResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  Subscription?: SubscriptionResolvers<ContextType>;
+  Timestamp?: GraphQLScalarType;
+  Topic?: TopicResolvers<ContextType>;
+  URL?: GraphQLScalarType;
+  User?: UserResolvers<ContextType>;
+  Void?: GraphQLScalarType;
+};
+
+declare module "graphql-ez" {
+  interface EZResolvers extends Resolvers<import("graphql-ez").EZContext> {}
+}

--- a/packages/services/actionsTopic/src/ez.ts
+++ b/packages/services/actionsTopic/src/ez.ts
@@ -1,0 +1,12 @@
+import { CreateApp } from "@graphql-ez/fastify";
+
+import { ezServicePreset } from "api-base";
+
+// This created the new GraphQL EZ instance, re-using a service preset with tools like GraphQL Codegen, GraphQL Altair and GraphQL Voyager
+export const { buildApp, gql, registerModule } = CreateApp({
+  ez: {
+    preset: ezServicePreset,
+  },
+});
+
+export * from "api-base";

--- a/packages/services/actionsTopic/src/ez.ts
+++ b/packages/services/actionsTopic/src/ez.ts
@@ -3,7 +3,7 @@ import { CreateApp } from "@graphql-ez/fastify";
 import { ezServicePreset } from "api-base";
 
 // This created the new GraphQL EZ instance, re-using a service preset with tools like GraphQL Codegen, GraphQL Altair and GraphQL Voyager
-export const { buildApp, gql, registerModule } = CreateApp({
+export const { buildApp, gql, registerModule, modulesApplication } = CreateApp({
   ez: {
     preset: ezServicePreset,
   },

--- a/packages/services/actionsTopic/src/index.ts
+++ b/packages/services/actionsTopic/src/index.ts
@@ -1,0 +1,32 @@
+import { baseServicesList, logger, pubSub, smartListen } from "api-base";
+import Fastify from "fastify";
+import { buildApp } from "./ez";
+
+// This creates the new web server
+const app = Fastify({
+  logger,
+  pluginTimeout: 30000,
+});
+
+// This builds the GraphQL EZ API
+const ezApp = buildApp({
+  async prepare() {
+    // This will add the new expected gql api modules
+    await import("./modules/index");
+  },
+});
+
+app.register(ezApp.fastifyPlugin);
+
+app.ready(async (err) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  // This will listen on the expected port, considering development mode and environment variables.
+  await smartListen(app, baseServicesList.actionsTopic);
+
+  // This will notify the gateway to re-introspect all the services, and detect possible changes
+  pubSub.publish("updateGateway", "actionsTopic");
+});

--- a/packages/services/actionsTopic/src/index.ts
+++ b/packages/services/actionsTopic/src/index.ts
@@ -25,8 +25,8 @@ app.ready(async (err) => {
   }
 
   // This will listen on the expected port, considering development mode and environment variables.
-  await smartListen(app, baseServicesList.actionsTopic);
+  await smartListen(app, baseServicesList.actionstopic);
 
   // This will notify the gateway to re-introspect all the services, and detect possible changes
-  pubSub.publish("updateGateway", "actionsTopic");
+  pubSub.publish("updateGateway", "actionstopic");
 });

--- a/packages/services/actionsTopic/src/modules/actionsTopic.ts
+++ b/packages/services/actionsTopic/src/modules/actionsTopic.ts
@@ -35,8 +35,16 @@ export const actionsTopicModule = registerModule(
     }
 
     input ActionsTopicInput {
+      "ID of the project."
       projectId: Int!
+      "Array of topic IDs where the search will be performed."
       topicsIds: [Int!]!
+      "Array of verbs to be used for action search."
+      verbNames: [String!]!
+      "Start interval for conducting the search."
+      startDate: DateTime!
+      "End interval for conducting the search."
+      endDate: DateTime!
     }
 
     "Paginated ActionsByContent"
@@ -193,6 +201,17 @@ export const actionsTopicModule = registerModule(
                           id: input.projectId,
                         },
                       },
+                      createdAt: {
+                        gte: input.startDate,
+                        lte: input.endDate,
+                      },
+                    },
+                    verbName: {
+                      in: input.verbNames,
+                    },
+                    createdAt: {
+                      gte: input.startDate,
+                      lte: input.endDate,
                     },
                   },
                   select: {
@@ -206,6 +225,7 @@ export const actionsTopicModule = registerModule(
                     },
                     verb: {
                       select: {
+                        id: true,
                         name: true,
                       },
                     },
@@ -232,6 +252,10 @@ export const actionsTopicModule = registerModule(
                     id: input.projectId,
                   },
                 },
+                createdAt: {
+                  gte: input.startDate,
+                  lte: input.endDate,
+                },
               },
               include: {
                 actions: {
@@ -240,6 +264,13 @@ export const actionsTopicModule = registerModule(
                       id: {
                         in: input.topicsIds,
                       },
+                    },
+                    verbName: {
+                      in: input.verbNames,
+                    },
+                    createdAt: {
+                      gte: input.startDate,
+                      lte: input.endDate,
                     },
                   },
                   select: {

--- a/packages/services/actionsTopic/src/modules/actionsTopic.ts
+++ b/packages/services/actionsTopic/src/modules/actionsTopic.ts
@@ -5,16 +5,29 @@ export const actionsTopicModule = registerModule(
   // This defines the types
   gql`
     extend type Query {
-      "ActionsTopic Query"
+      """
+      This service retrieves all actions performed on the specified topics through the input.
+      These actions are grouped by user and content.
+      """
       actionsTopic: ActionsTopicQueries!
     }
 
     type ActionsTopicQueries {
-      allActionsByTopic(
+      """
+      Returns all actions performed, grouped by Content.
+      Pagination parameters are used to control the number of returned results,
+      making this parameter mandatory.
+      """
+      allActionsByContent(
         pagination: CursorConnectionArgs!
         input: ActionsTopicInput!
-      ): ActionsByTopicConnection!
+      ): ActionsByContentConnection!
 
+      """
+      Returns all actions performed, grouped by users.
+      Pagination parameters are used to control the number of returned results,
+      making this parameter mandatory.
+      """
       allActionsByUser(
         pagination: CursorConnectionArgs!
         input: ActionsTopicInput!
@@ -26,42 +39,46 @@ export const actionsTopicModule = registerModule(
       topicsIds: [Int!]!
     }
 
-    type ActionsByTopicConnection implements Connection {
+    "Paginated ActionsByContent"
+    type ActionsByContentConnection implements Connection {
       "Nodes of the current page"
-      nodes: [AllTopicsReturn!]!
+      nodes: [AllActionsByContent!]!
 
       "Pagination related information"
       pageInfo: PageInfo!
     }
+    "Paginated ActionsByUser"
     type ActionsByUserConnection implements Connection {
       "Nodes of the current page"
-      nodes: [AllActionsByUserReturn!]!
+      nodes: [AllActionsByUser!]!
 
       "Pagination related information"
       pageInfo: PageInfo!
     }
 
-    type AllTopicsReturn {
+    type AllActionsByContent {
+      "Unique numeric identifier"
       id: IntID!
+      "Unique string identifier"
       code: String!
+      "Arbitrary JSON object data"
       json: JSONObject!
+      "KCs associated with the content"
       kcs: [KC!]!
+      "Actions performed on the content."
       actions: [Action!]!
     }
 
-    type AllActionsByContentReturn {
+    type AllActionsByUser {
+      "Unique numeric identifier"
       id: IntID!
-      code: String!
-      kcs: [KC!]!
-      json: JSONObject!
-      actions: [Action!]!
-    }
-
-    type AllActionsByUserReturn {
-      id: IntID!
+      "Date of creation"
       createdAt: DateTime!
+      "Email Address"
       email: String!
+      "Model States associated with user"
       modelStates: JSON!
+      "Actions performed by user"
       actions: [Action!]!
     }
 
@@ -151,7 +168,7 @@ export const actionsTopicModule = registerModule(
         },
       },
       ActionsTopicQueries: {
-        allActionsByTopic(_root, { pagination, input }, { prisma }) {
+        allActionsByContent(_root, { pagination, input }, { prisma }) {
           return ResolveCursorConnection(pagination, (connection) => {
             return prisma.content.findMany({
               ...connection,

--- a/packages/services/actionsTopic/src/modules/actionsTopic.ts
+++ b/packages/services/actionsTopic/src/modules/actionsTopic.ts
@@ -23,7 +23,7 @@ export const actionsTopicModule = registerModule(
 
     input ActionsTopicInput {
       projectId: Int!
-      topicsIds: Int!
+      topicsIds: [Int!]!
     }
 
     type ActionsByTopicConnection implements Connection {
@@ -59,6 +59,7 @@ export const actionsTopicModule = registerModule(
 
     type AllActionsByUserReturn {
       id: IntID!
+      createdAt: DateTime!
       email: String!
       modelStates: JSON!
       actions: [Action!]!
@@ -160,7 +161,9 @@ export const actionsTopicModule = registerModule(
               where: {
                 topics: {
                   some: {
-                    id: input.topicsIds,
+                    id: {
+                      in: input.topicsIds,
+                    },
                   },
                 },
               },
@@ -217,7 +220,9 @@ export const actionsTopicModule = registerModule(
                 actions: {
                   where: {
                     topic: {
-                      id: input.topicsIds,
+                      id: {
+                        in: input.topicsIds,
+                      },
                     },
                   },
                   select: {

--- a/packages/services/actionsTopic/src/modules/actionsTopic.ts
+++ b/packages/services/actionsTopic/src/modules/actionsTopic.ts
@@ -288,6 +288,12 @@ export const actionsTopicModule = registerModule(
                   orderBy: {
                     createdAt: "desc",
                   },
+                  where: {
+                    createdAt: {
+                      gte: input.startDate,
+                      lte: input.endDate,
+                    },
+                  },
                 },
               },
             });

--- a/packages/services/actionsTopic/src/modules/actionsTopic.ts
+++ b/packages/services/actionsTopic/src/modules/actionsTopic.ts
@@ -1,0 +1,246 @@
+import { ResolveCursorConnection } from "api-base";
+import { gql, registerModule } from "../ez";
+
+export const actionsTopicModule = registerModule(
+  // This defines the types
+  gql`
+    extend type Query {
+      "ActionsTopic Query"
+      actionsTopic: ActionsTopicQueries!
+    }
+
+    type ActionsTopicQueries {
+      allActionsByTopic(
+        pagination: CursorConnectionArgs!
+        input: ActionsTopicInput!
+      ): ActionsByTopicConnection!
+
+      allActionsByUser(
+        pagination: CursorConnectionArgs!
+        input: ActionsTopicInput!
+      ): ActionsByUserConnection!
+    }
+
+    input ActionsTopicInput {
+      projectId: Int!
+      topicsIds: Int!
+    }
+
+    type ActionsByTopicConnection implements Connection {
+      "Nodes of the current page"
+      nodes: [AllTopicsReturn!]!
+
+      "Pagination related information"
+      pageInfo: PageInfo!
+    }
+    type ActionsByUserConnection implements Connection {
+      "Nodes of the current page"
+      nodes: [AllActionsByUserReturn!]!
+
+      "Pagination related information"
+      pageInfo: PageInfo!
+    }
+
+    type AllTopicsReturn {
+      id: IntID!
+      code: String!
+      json: JSONObject!
+      kcs: [KC!]!
+      actions: [Action!]!
+    }
+
+    type AllActionsByContentReturn {
+      id: IntID!
+      code: String!
+      kcs: [KC!]!
+      json: JSONObject!
+      actions: [Action!]!
+    }
+
+    type AllActionsByUserReturn {
+      id: IntID!
+      email: String!
+      modelStates: JSON!
+      actions: [Action!]!
+    }
+
+    "User entity"
+    type User {
+      "Unique numeric identifier"
+      id: IntID!
+    }
+
+    type ActionVerb {
+      "Unique numeric identifier"
+      id: IntID!
+
+      "Name of the verb"
+      name: String!
+    }
+
+    "Content entity"
+    type Content {
+      "Unique numeric identifier"
+      id: IntID!
+    }
+
+    type KC {
+      "Unique numeric identifier"
+      id: IntID!
+    }
+
+    "Topic entity"
+    type Topic {
+      "Unique numeric identifier"
+      id: IntID!
+    }
+
+    type Action {
+      "Unique numeric identifier"
+      id: IntID!
+
+      "Type of action"
+      verb: ActionVerb!
+
+      "Timestamp of the action, set by the action emitter"
+      timestamp: Timestamp!
+
+      "Arbitrary numeric result"
+      result: Float
+
+      "User that emitted the action"
+      user: User
+
+      "Related content"
+      content: Content
+
+      "Related topic"
+      topic: Topic
+
+      "Related KCs"
+      kcs: [KC!]!
+
+      "Arbitrary step identifier"
+      stepID: ID
+
+      "Arbitrary hint identifier"
+      hintID: ID
+
+      "Arbitrary numeric amount"
+      amount: Float
+
+      "Arbitrary string content detail"
+      detail: String
+
+      "Arbitrary JSON object data"
+      extra: JSONObject
+
+      "Timestamp of the action, set by the database on row creation"
+      createdAt: DateTime!
+    }
+  `,
+  {
+    id: "ActionsTopic",
+    dirname: import.meta.url,
+    // This defines the resolvers associated with the defined types
+    resolvers: {
+      Query: {
+        actionsTopic() {
+          return {};
+        },
+      },
+      ActionsTopicQueries: {
+        allActionsByTopic(_root, { pagination, input }, { prisma }) {
+          return ResolveCursorConnection(pagination, (connection) => {
+            return prisma.content.findMany({
+              ...connection,
+              orderBy: {
+                id: "asc",
+              },
+              where: {
+                topics: {
+                  some: {
+                    id: input.topicsIds,
+                  },
+                },
+              },
+              include: {
+                actions: {
+                  where: {
+                    user: {
+                      projects: {
+                        some: {
+                          id: input.projectId,
+                        },
+                      },
+                    },
+                  },
+                  select: {
+                    id: true,
+                    stepID: true,
+                    user: {
+                      select: {
+                        id: true,
+                        email: true,
+                      },
+                    },
+                    verb: {
+                      select: {
+                        name: true,
+                      },
+                    },
+                  },
+                },
+                kcs: {
+                  select: {
+                    id: true,
+                    code: true,
+                    label: true,
+                  },
+                },
+              },
+            });
+          });
+        },
+        allActionsByUser(_root, { pagination, input }, { prisma }) {
+          return ResolveCursorConnection(pagination, (connection) => {
+            return prisma.user.findMany({
+              ...connection,
+              where: {
+                projects: {
+                  some: {
+                    id: input.projectId,
+                  },
+                },
+              },
+              include: {
+                actions: {
+                  where: {
+                    topic: {
+                      id: input.topicsIds,
+                    },
+                  },
+                  select: {
+                    id: true,
+                    stepID: true,
+                    verb: {
+                      select: {
+                        name: true,
+                      },
+                    },
+                  },
+                },
+                modelStates: {
+                  take: 1,
+                  orderBy: {
+                    createdAt: "desc",
+                  },
+                },
+              },
+            });
+          });
+        },
+      },
+    },
+  }
+);

--- a/packages/services/actionsTopic/src/modules/index.ts
+++ b/packages/services/actionsTopic/src/modules/index.ts
@@ -1,0 +1,1 @@
+export * from "./actionsTopic";

--- a/packages/services/actionsTopic/tsconfig.json
+++ b/packages/services/actionsTopic/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["**/*"],
+  "exclude": ["**/node_modules"]
+}

--- a/packages/services/list.ts
+++ b/packages/services/list.ts
@@ -7,6 +7,7 @@ export const baseServicesList = {
   state: 3007,
   model: 3008,
   contentSelection: 3009,
+  actionsTopic: 3010,
 } as const;
 
 export const servicesNames = Object.keys(baseServicesList) as ServiceName[];

--- a/packages/services/list.ts
+++ b/packages/services/list.ts
@@ -7,7 +7,7 @@ export const baseServicesList = {
   state: 3007,
   model: 3008,
   contentSelection: 3009,
-  actionsTopic: 3010,
+  actionstopic: 3010,
 } as const;
 
 export const servicesNames = Object.keys(baseServicesList) as ServiceName[];

--- a/packages/testing/src/generated/graphql.ts
+++ b/packages/testing/src/generated/graphql.ts
@@ -166,8 +166,16 @@ export type ActionsConnection = Connection & {
 };
 
 export type ActionsTopicInput = {
+  /** End interval for conducting the search. */
+  endDate: Scalars["DateTime"];
+  /** ID of the project. */
   projectId: Scalars["Int"];
+  /** Start interval for conducting the search. */
+  startDate: Scalars["DateTime"];
+  /** Array of topic IDs where the search will be performed. */
   topicsIds: Array<Scalars["Int"]>;
+  /** Array of verbs to be used for action search. */
+  verbNames: Array<Scalars["String"]>;
 };
 
 export type ActionsTopicQueries = {

--- a/packages/testing/src/generated/graphql.ts
+++ b/packages/testing/src/generated/graphql.ts
@@ -138,6 +138,22 @@ export type ActionVerb = {
   name: Scalars["String"];
 };
 
+export type ActionsByTopicConnection = Connection & {
+  __typename?: "ActionsByTopicConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllTopicsReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
+export type ActionsByUserConnection = Connection & {
+  __typename?: "ActionsByUserConnection";
+  /** Nodes of the current page */
+  nodes: Array<AllActionsByUserReturn>;
+  /** Pagination related information */
+  pageInfo: PageInfo;
+};
+
 /** Paginated Actions */
 export type ActionsConnection = Connection & {
   __typename?: "ActionsConnection";
@@ -145,6 +161,27 @@ export type ActionsConnection = Connection & {
   nodes: Array<Action>;
   /** Pagination related information */
   pageInfo: PageInfo;
+};
+
+export type ActionsTopicInput = {
+  projectId: Scalars["Int"];
+  topicsIds: Scalars["Int"];
+};
+
+export type ActionsTopicQueries = {
+  __typename?: "ActionsTopicQueries";
+  allActionsByTopic: ActionsByTopicConnection;
+  allActionsByUser: ActionsByUserConnection;
+};
+
+export type ActionsTopicQueriesallActionsByTopicArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
+};
+
+export type ActionsTopicQueriesallActionsByUserArgs = {
+  input: ActionsTopicInput;
+  pagination: CursorConnectionArgs;
 };
 
 /** Paginated Actions Verbs */
@@ -622,6 +659,32 @@ export type AdminUsersFilter = {
   tags?: InputMaybe<Array<Scalars["String"]>>;
   /** Filter by text search inside "email", "name", "tags" or "projects" */
   textSearch?: InputMaybe<Scalars["String"]>;
+};
+
+export type AllActionsByContentReturn = {
+  __typename?: "AllActionsByContentReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<KC>;
+};
+
+export type AllActionsByUserReturn = {
+  __typename?: "AllActionsByUserReturn";
+  actions: Array<Action>;
+  email: Scalars["String"];
+  id: Scalars["IntID"];
+  modelStates: Scalars["JSON"];
+};
+
+export type AllTopicsReturn = {
+  __typename?: "AllTopicsReturn";
+  actions: Array<Action>;
+  code: Scalars["String"];
+  id: Scalars["IntID"];
+  json: Scalars["JSONObject"];
+  kcs: Array<KC>;
 };
 
 /** Pagination Interface */
@@ -1418,6 +1481,8 @@ export type ProjectsConnection = Connection & {
 
 export type Query = {
   __typename?: "Query";
+  /** ActionsTopic Query */
+  actionsTopic: ActionsTopicQueries;
   /** Admin related actions queries, only authenticated users with the role "ADMIN" can access */
   adminActions: AdminActionQueries;
   /** Admin related content queries, only authenticated users with the role "ADMIN" can access */

--- a/packages/testing/src/generated/graphql.ts
+++ b/packages/testing/src/generated/graphql.ts
@@ -165,7 +165,7 @@ export type ActionsConnection = Connection & {
 
 export type ActionsTopicInput = {
   projectId: Scalars["Int"];
-  topicsIds: Scalars["Int"];
+  topicsIds: Array<Scalars["Int"]>;
 };
 
 export type ActionsTopicQueries = {
@@ -673,6 +673,7 @@ export type AllActionsByContentReturn = {
 export type AllActionsByUserReturn = {
   __typename?: "AllActionsByUserReturn";
   actions: Array<Action>;
+  createdAt: Scalars["DateTime"];
   email: Scalars["String"];
   id: Scalars["IntID"];
   modelStates: Scalars["JSON"];

--- a/packages/testing/src/generated/graphql.ts
+++ b/packages/testing/src/generated/graphql.ts
@@ -138,18 +138,20 @@ export type ActionVerb = {
   name: Scalars["String"];
 };
 
-export type ActionsByTopicConnection = Connection & {
-  __typename?: "ActionsByTopicConnection";
+/** Paginated ActionsByContent */
+export type ActionsByContentConnection = Connection & {
+  __typename?: "ActionsByContentConnection";
   /** Nodes of the current page */
-  nodes: Array<AllTopicsReturn>;
+  nodes: Array<AllActionsByContent>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
 
+/** Paginated ActionsByUser */
 export type ActionsByUserConnection = Connection & {
   __typename?: "ActionsByUserConnection";
   /** Nodes of the current page */
-  nodes: Array<AllActionsByUserReturn>;
+  nodes: Array<AllActionsByUser>;
   /** Pagination related information */
   pageInfo: PageInfo;
 };
@@ -170,11 +172,21 @@ export type ActionsTopicInput = {
 
 export type ActionsTopicQueries = {
   __typename?: "ActionsTopicQueries";
-  allActionsByTopic: ActionsByTopicConnection;
+  /**
+   * Returns all actions performed, grouped by Content.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
+  allActionsByContent: ActionsByContentConnection;
+  /**
+   * Returns all actions performed, grouped by users.
+   * Pagination parameters are used to control the number of returned results,
+   * making this parameter mandatory.
+   */
   allActionsByUser: ActionsByUserConnection;
 };
 
-export type ActionsTopicQueriesallActionsByTopicArgs = {
+export type ActionsTopicQueriesallActionsByContentArgs = {
   input: ActionsTopicInput;
   pagination: CursorConnectionArgs;
 };
@@ -661,31 +673,32 @@ export type AdminUsersFilter = {
   textSearch?: InputMaybe<Scalars["String"]>;
 };
 
-export type AllActionsByContentReturn = {
-  __typename?: "AllActionsByContentReturn";
+export type AllActionsByContent = {
+  __typename?: "AllActionsByContent";
+  /** Actions performed on the content. */
   actions: Array<Action>;
+  /** Unique string identifier */
   code: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Arbitrary JSON object data */
   json: Scalars["JSONObject"];
+  /** KCs associated with the content */
   kcs: Array<KC>;
 };
 
-export type AllActionsByUserReturn = {
-  __typename?: "AllActionsByUserReturn";
+export type AllActionsByUser = {
+  __typename?: "AllActionsByUser";
+  /** Actions performed by user */
   actions: Array<Action>;
+  /** Date of creation */
   createdAt: Scalars["DateTime"];
+  /** Email Address */
   email: Scalars["String"];
+  /** Unique numeric identifier */
   id: Scalars["IntID"];
+  /** Model States associated with user */
   modelStates: Scalars["JSON"];
-};
-
-export type AllTopicsReturn = {
-  __typename?: "AllTopicsReturn";
-  actions: Array<Action>;
-  code: Scalars["String"];
-  id: Scalars["IntID"];
-  json: Scalars["JSONObject"];
-  kcs: Array<KC>;
 };
 
 /** Pagination Interface */
@@ -1482,7 +1495,10 @@ export type ProjectsConnection = Connection & {
 
 export type Query = {
   __typename?: "Query";
-  /** ActionsTopic Query */
+  /**
+   * This service retrieves all actions performed on the specified topics through the input.
+   * These actions are grouped by user and content.
+   */
   actionsTopic: ActionsTopicQueries;
   /** Admin related actions queries, only authenticated users with the role "ADMIN" can access */
   adminActions: AdminActionQueries;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 onlyBuiltDependencies:
   - fsevents
 
@@ -682,6 +686,15 @@ importers:
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
+
+  packages/services/actionsTopic:
+    dependencies:
+      api-base:
+        specifier: workspace:^0.0.1
+        version: link:../../api-base
+      db:
+        specifier: workspace:^0.0.1
+        version: link:../../db
 
   packages/services/content:
     dependencies:

--- a/schema.gql
+++ b/schema.gql
@@ -132,7 +132,7 @@ type ActionsConnection implements Connection {
 
 input ActionsTopicInput {
   projectId: Int!
-  topicsIds: Int!
+  topicsIds: [Int!]!
 }
 
 type ActionsTopicQueries {
@@ -505,6 +505,7 @@ type AllActionsByContentReturn {
 
 type AllActionsByUserReturn {
   actions: [Action!]!
+  createdAt: DateTime!
   email: String!
   id: IntID!
   modelStates: JSON!

--- a/schema.gql
+++ b/schema.gql
@@ -108,16 +108,18 @@ type ActionVerb {
   name: String!
 }
 
-type ActionsByTopicConnection implements Connection {
+"Paginated ActionsByContent"
+type ActionsByContentConnection implements Connection {
   "Nodes of the current page"
-  nodes: [AllTopicsReturn!]!
+  nodes: [AllActionsByContent!]!
   "Pagination related information"
   pageInfo: PageInfo!
 }
 
+"Paginated ActionsByUser"
 type ActionsByUserConnection implements Connection {
   "Nodes of the current page"
-  nodes: [AllActionsByUserReturn!]!
+  nodes: [AllActionsByUser!]!
   "Pagination related information"
   pageInfo: PageInfo!
 }
@@ -136,10 +138,20 @@ input ActionsTopicInput {
 }
 
 type ActionsTopicQueries {
-  allActionsByTopic(
+  """
+  Returns all actions performed, grouped by Content.
+  Pagination parameters are used to control the number of returned results,
+  making this parameter mandatory.
+  """
+  allActionsByContent(
     input: ActionsTopicInput!
     pagination: CursorConnectionArgs!
-  ): ActionsByTopicConnection!
+  ): ActionsByContentConnection!
+  """
+  Returns all actions performed, grouped by users.
+  Pagination parameters are used to control the number of returned results,
+  making this parameter mandatory.
+  """
   allActionsByUser(
     input: ActionsTopicInput!
     pagination: CursorConnectionArgs!
@@ -495,28 +507,30 @@ input AdminUsersFilter {
   textSearch: String
 }
 
-type AllActionsByContentReturn {
+type AllActionsByContent {
+  "Actions performed on the content."
   actions: [Action!]!
+  "Unique string identifier"
   code: String!
+  "Unique numeric identifier"
   id: IntID!
+  "Arbitrary JSON object data"
   json: JSONObject!
+  "KCs associated with the content"
   kcs: [KC!]!
 }
 
-type AllActionsByUserReturn {
+type AllActionsByUser {
+  "Actions performed by user"
   actions: [Action!]!
+  "Date of creation"
   createdAt: DateTime!
+  "Email Address"
   email: String!
+  "Unique numeric identifier"
   id: IntID!
+  "Model States associated with user"
   modelStates: JSON!
-}
-
-type AllTopicsReturn {
-  actions: [Action!]!
-  code: String!
-  id: IntID!
-  json: JSONObject!
-  kcs: [KC!]!
 }
 
 "Pagination Interface"
@@ -1311,7 +1325,10 @@ type ProjectsConnection implements Connection {
 }
 
 type Query {
-  "ActionsTopic Query"
+  """
+  This service retrieves all actions performed on the specified topics through the input.
+  These actions are grouped by user and content.
+  """
   actionsTopic: ActionsTopicQueries!
   """
   Admin related actions queries, only authenticated users with the role "ADMIN" can access

--- a/schema.gql
+++ b/schema.gql
@@ -108,12 +108,42 @@ type ActionVerb {
   name: String!
 }
 
+type ActionsByTopicConnection implements Connection {
+  "Nodes of the current page"
+  nodes: [AllTopicsReturn!]!
+  "Pagination related information"
+  pageInfo: PageInfo!
+}
+
+type ActionsByUserConnection implements Connection {
+  "Nodes of the current page"
+  nodes: [AllActionsByUserReturn!]!
+  "Pagination related information"
+  pageInfo: PageInfo!
+}
+
 "Paginated Actions"
 type ActionsConnection implements Connection {
   "Nodes of the current page"
   nodes: [Action!]!
   "Pagination related information"
   pageInfo: PageInfo!
+}
+
+input ActionsTopicInput {
+  projectId: Int!
+  topicsIds: Int!
+}
+
+type ActionsTopicQueries {
+  allActionsByTopic(
+    input: ActionsTopicInput!
+    pagination: CursorConnectionArgs!
+  ): ActionsByTopicConnection!
+  allActionsByUser(
+    input: ActionsTopicInput!
+    pagination: CursorConnectionArgs!
+  ): ActionsByUserConnection!
 }
 
 "Paginated Actions Verbs"
@@ -463,6 +493,29 @@ input AdminUsersFilter {
   Filter by text search inside "email", "name", "tags" or "projects"
   """
   textSearch: String
+}
+
+type AllActionsByContentReturn {
+  actions: [Action!]!
+  code: String!
+  id: IntID!
+  json: JSONObject!
+  kcs: [KC!]!
+}
+
+type AllActionsByUserReturn {
+  actions: [Action!]!
+  email: String!
+  id: IntID!
+  modelStates: JSON!
+}
+
+type AllTopicsReturn {
+  actions: [Action!]!
+  code: String!
+  id: IntID!
+  json: JSONObject!
+  kcs: [KC!]!
 }
 
 "Pagination Interface"
@@ -1257,6 +1310,8 @@ type ProjectsConnection implements Connection {
 }
 
 type Query {
+  "ActionsTopic Query"
+  actionsTopic: ActionsTopicQueries!
   """
   Admin related actions queries, only authenticated users with the role "ADMIN" can access
   """

--- a/schema.gql
+++ b/schema.gql
@@ -133,8 +133,16 @@ type ActionsConnection implements Connection {
 }
 
 input ActionsTopicInput {
+  "End interval for conducting the search."
+  endDate: DateTime!
+  "ID of the project."
   projectId: Int!
+  "Start interval for conducting the search."
+  startDate: DateTime!
+  "Array of topic IDs where the search will be performed."
   topicsIds: [Int!]!
+  "Array of verbs to be used for action search."
+  verbNames: [String!]!
 }
 
 type ActionsTopicQueries {


### PR DESCRIPTION
Dado el desarrollo del proyecto de un dashboard, ha surgido la necesidad de implementar un servicio que retorne todas las acciones realizadas en el sistema, organizadas tanto por usuarios como por contenidos. En respuesta a esto, el presente pull request introduce el nuevo servicio denominado "actionsTopic", el cual incluye dos campos principales: actionsByContent y actionsByUser.

- **actionsByContent**: entrega el contenido paginado del cual se incluye el id, codigo , json, kcs y acciones
- **actionsByUser**: entrega los usuarios paginado del cual se incluye el id, email , modelo, fecha de creacion del usuario y acciones