### PR TITLE
Refactor Auth0 user import to bulk import job API

### DIFF
--- a/packages/client-admin/src/pages/users.tsx
+++ b/packages/client-admin/src/pages/users.tsx
@@ -468,7 +468,8 @@ function ImportAuth0Users() {
                   </ListItem>
                   <ListItem>
                     3. Copy the token (valid for 24 hours). Required scopes:{" "}
-                    <b>create:users</b>, <b>read:users</b>
+                    <b>create:users</b>, <b>read:users</b>,{" "}
+                    <b>read:connections</b>
                   </ListItem>
                 </List>
                 <Button

--- a/packages/services/users/package.json
+++ b/packages/services/users/package.json
@@ -10,10 +10,12 @@
   },
   "dependencies": {
     "api-base": "workspace:^0.0.1",
+    "bcryptjs": "^2.4.3",
     "db": "workspace:^0.0.1",
     "p-map": "^5.5.0"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^18.11.18",
     "graphql": "^16.6.0",
     "graphql-ez": "^0.16.0",

--- a/packages/services/users/src/modules/users.ts
+++ b/packages/services/users/src/modules/users.ts
@@ -1,5 +1,5 @@
 import { getNodeIdList } from "api-base";
-import { hashSync } from "bcryptjs";
+import bcryptjs from "bcryptjs";
 import pMap from "p-map";
 import { FormData, request } from "undici";
 import { z } from "zod";
@@ -498,7 +498,7 @@ export const usersModule = registerModule(
           const usersPayload = users.map(({ email, password }) => ({
             email,
             email_verified: false,
-            password_hash: hashSync(password, 10),
+            password_hash: bcryptjs.hashSync(password, 10),
           }));
 
           // 3. Submit bulk import job

--- a/packages/services/users/src/modules/users.ts
+++ b/packages/services/users/src/modules/users.ts
@@ -1,7 +1,43 @@
 import { getNodeIdList } from "api-base";
+import { hashSync } from "bcryptjs";
 import pMap from "p-map";
-import { request } from "undici";
+import { FormData, request } from "undici";
+import { z } from "zod";
 import { gql, registerModule, ResolveCursorConnection } from "../ez";
+
+const Auth0ErrorBody = z.object({
+  message: z.string().optional(),
+  error: z.string().optional(),
+});
+
+const Auth0Connections = z.array(
+  z.object({ id: z.string(), name: z.string() })
+);
+
+const Auth0Job = z.object({
+  id: z.string(),
+  status: z.string(),
+});
+
+const Auth0JobStatus = z.object({
+  id: z.string(),
+  status: z.string(),
+  summary: z
+    .object({
+      total: z.number(),
+      inserted: z.number(),
+      updated: z.number(),
+      failed: z.number(),
+    })
+    .optional(),
+});
+
+const Auth0JobErrors = z.array(
+  z.object({
+    user: z.object({ email: z.string() }),
+    errors: z.array(z.object({ code: z.string(), message: z.string() })),
+  })
+);
 
 export const usersModule = registerModule(
   gql`
@@ -378,7 +414,8 @@ export const usersModule = registerModule(
             throw new Error("AUTH0_DOMAIN environment variable is not set");
           }
 
-          const response = await request(
+          // Test read:users scope
+          const usersResponse = await request(
             `https://${AUTH0_DOMAIN}/api/v2/users?per_page=1`,
             {
               method: "GET",
@@ -388,24 +425,41 @@ export const usersModule = registerModule(
             }
           );
 
-          if (response.statusCode === 200) {
-            return true;
-          }
-
-          if (response.statusCode === 401) {
+          if (usersResponse.statusCode === 401) {
             throw new Error("Invalid or expired Auth0 token");
           }
 
-          if (response.statusCode === 403) {
+          if (usersResponse.statusCode === 403) {
             throw new Error(
-              "Insufficient permissions. Required scopes: read:users"
+              "Insufficient permissions. Required scopes: read:users, create:users, read:connections"
             );
           }
 
-          const body = (await response.body.json()) as { message?: string };
-          throw new Error(
-            body.message || `Auth0 API error: ${response.statusCode}`
+          if (usersResponse.statusCode !== 200) {
+            const body = Auth0ErrorBody.parse(await usersResponse.body.json());
+            throw new Error(
+              body.message || `Auth0 API error: ${usersResponse.statusCode}`
+            );
+          }
+
+          // Test read:connections scope (needed for bulk import)
+          const connResponse = await request(
+            `https://${AUTH0_DOMAIN}/api/v2/connections?per_page=1`,
+            {
+              method: "GET",
+              headers: {
+                Authorization: `Bearer ${auth0Token}`,
+              },
+            }
           );
+
+          if (connResponse.statusCode === 403) {
+            throw new Error(
+              "Insufficient permissions. Missing scope: read:connections"
+            );
+          }
+
+          return true;
         },
         async importAuth0Users(
           _root,
@@ -417,124 +471,179 @@ export const usersModule = registerModule(
             throw new Error("AUTH0_DOMAIN environment variable is not set");
           }
 
-          const results = await pMap(
-            users,
-            async ({ email, password }) => {
-              try {
-                // Create user in Auth0
-                const response = await request(
-                  `https://${AUTH0_DOMAIN}/api/v2/users`,
-                  {
-                    method: "POST",
-                    headers: {
-                      "Content-Type": "application/json",
-                      Authorization: `Bearer ${auth0Token}`,
-                    },
-                    body: JSON.stringify({
-                      connection: "Username-Password-Authentication",
-                      email,
-                      password,
-                    }),
-                  }
-                );
-
-                if (response.statusCode !== 201) {
-                  const body = (await response.body.json()) as {
-                    message?: string;
-                    error?: string;
-                  };
-                  let errorMessage =
-                    body.message ||
-                    body.error ||
-                    `Auth0 error: ${response.statusCode}`;
-
-                  if (response.statusCode === 409) {
-                    errorMessage = "User already exists in Auth0";
-                  } else if (response.statusCode === 400) {
-                    errorMessage =
-                      body.message ||
-                      "Invalid input (weak password or invalid email)";
-                  } else if (response.statusCode === 401) {
-                    errorMessage = "Invalid or expired Auth0 token";
-                  } else if (response.statusCode === 403) {
-                    errorMessage =
-                      "Insufficient permissions. Required scopes: create:users";
-                  } else if (response.statusCode === 429) {
-                    errorMessage =
-                      "Rate limit exceeded. Please wait and try again.";
-                  }
-
-                  return {
-                    email,
-                    success: false,
-                    error: errorMessage,
-                    user: null,
-                  };
-                }
-
-                // Upsert user in local database
-                const user = await prisma.user.upsert({
-                  create: {
-                    email,
-                    projects: projectIds?.length
-                      ? {
-                          connect: projectIds.map((id) => ({ id })),
-                        }
-                      : undefined,
-                    tags: tags?.length
-                      ? {
-                          set: tags,
-                        }
-                      : undefined,
-                  },
-                  where: {
-                    email,
-                  },
-                  update: {
-                    projects: projectIds?.length
-                      ? {
-                          connect: projectIds.map((id) => ({ id })),
-                        }
-                      : undefined,
-                    tags: tags?.length
-                      ? {
-                          push: tags,
-                        }
-                      : undefined,
-                  },
-                });
-
-                return {
-                  email,
-                  success: true,
-                  error: null,
-                  user,
-                };
-              } catch (error) {
-                return {
-                  email,
-                  success: false,
-                  error:
-                    error instanceof Error
-                      ? error.message
-                      : "Unknown error occurred",
-                  user: null,
-                };
-              }
-            },
+          // 1. Fetch connection_id for Username-Password-Authentication
+          const connectionsResponse = await request(
+            `https://${AUTH0_DOMAIN}/api/v2/connections?name=Username-Password-Authentication`,
             {
-              concurrency: 2,
+              method: "GET",
+              headers: {
+                Authorization: `Bearer ${auth0Token}`,
+              },
             }
           );
+
+          const connections = Auth0Connections.parse(
+            await connectionsResponse.body.json()
+          );
+
+          if (!connections.length) {
+            throw new Error(
+              'Could not find connection "Username-Password-Authentication"'
+            );
+          }
+
+          const connectionId = connections[0]!.id;
+
+          // 2. Hash passwords with bcrypt and build JSON payload
+          const usersPayload = users.map(({ email, password }) => ({
+            email,
+            email_verified: false,
+            password_hash: hashSync(password, 10),
+          }));
+
+          // 3. Submit bulk import job
+          const formData = new FormData();
+          const usersBlob = new Blob([JSON.stringify(usersPayload)], {
+            type: "application/json",
+          });
+          formData.append("users", usersBlob, "users.json");
+          formData.append("connection_id", connectionId);
+          formData.append("upsert", "true");
+          formData.append("send_completion_email", "false");
+
+          const jobResponse = await request(
+            `https://${AUTH0_DOMAIN}/api/v2/jobs/users-imports`,
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${auth0Token}`,
+              },
+              body: formData,
+            }
+          );
+
+          if (jobResponse.statusCode !== 202) {
+            const errorBody = Auth0ErrorBody.parse(
+              await jobResponse.body.json()
+            );
+            throw new Error(
+              errorBody.message ||
+                `Auth0 bulk import failed: ${jobResponse.statusCode}`
+            );
+          }
+
+          const job = Auth0Job.parse(await jobResponse.body.json());
+
+          // 4. Poll for job completion
+          const MAX_POLL_TIME_MS = 120_000;
+          const POLL_INTERVAL_MS = 2_000;
+          const startTime = Date.now();
+
+          let jobStatus: z.infer<typeof Auth0JobStatus>;
+
+          while (true) {
+            if (Date.now() - startTime > MAX_POLL_TIME_MS) {
+              throw new Error(
+                `Auth0 import job ${job.id} timed out after ${
+                  MAX_POLL_TIME_MS / 1000
+                }s. Check Auth0 Dashboard for job status.`
+              );
+            }
+
+            await new Promise((resolve) =>
+              setTimeout(resolve, POLL_INTERVAL_MS)
+            );
+
+            const statusResponse = await request(
+              `https://${AUTH0_DOMAIN}/api/v2/jobs/${job.id}`,
+              {
+                method: "GET",
+                headers: {
+                  Authorization: `Bearer ${auth0Token}`,
+                },
+              }
+            );
+
+            jobStatus = Auth0JobStatus.parse(await statusResponse.body.json());
+
+            if (
+              jobStatus.status === "completed" ||
+              jobStatus.status === "failed"
+            ) {
+              break;
+            }
+          }
+
+          // 5. Fetch per-user errors
+          const errorsResponse = await request(
+            `https://${AUTH0_DOMAIN}/api/v2/jobs/${job.id}/errors`,
+            {
+              method: "GET",
+              headers: {
+                Authorization: `Bearer ${auth0Token}`,
+              },
+            }
+          );
+
+          const jobErrors = Auth0JobErrors.parse(
+            await errorsResponse.body.json()
+          );
+
+          const failedEmailsMap = new Map<string, string>();
+          for (const error of jobErrors) {
+            const email = error.user.email;
+            const message = error.errors.map((e) => e.message).join("; ");
+            failedEmailsMap.set(email, message);
+          }
+
+          // 6. Upsert successful users in local DB
+          const successfulEmails = users
+            .map((u) => u.email)
+            .filter((email) => !failedEmailsMap.has(email));
+
+          const upsertedUsers = await pMap(
+            successfulEmails,
+            async (email) => {
+              return prisma.user.upsert({
+                create: {
+                  email,
+                  projects: projectIds?.length
+                    ? { connect: projectIds.map((id) => ({ id })) }
+                    : undefined,
+                  tags: tags?.length ? { set: tags } : undefined,
+                },
+                where: { email },
+                update: {
+                  projects: projectIds?.length
+                    ? { connect: projectIds.map((id) => ({ id })) }
+                    : undefined,
+                  tags: tags?.length ? { push: tags } : undefined,
+                },
+              });
+            },
+            { concurrency: 4 }
+          );
+
+          const usersByEmail = new Map(upsertedUsers.map((u) => [u.email, u]));
+
+          // 7. Assemble results
+          const results = users.map(({ email }) => {
+            const errorMessage = failedEmailsMap.get(email);
+            if (errorMessage) {
+              return { email, success: false, error: errorMessage, user: null };
+            }
+            return {
+              email,
+              success: true,
+              error: null,
+              user: usersByEmail.get(email) || null,
+            };
+          });
 
           const successCount = results.filter((r) => r.success).length;
           const failureCount = results.filter((r) => !r.success).length;
 
-          return {
-            results,
-            successCount,
-            failureCount,
-          };
+          return { results, successCount, failureCount };
         },
       },
       AdminUserQueries: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -831,6 +831,9 @@ importers:
       api-base:
         specifier: workspace:^0.0.1
         version: link:../../api-base
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       db:
         specifier: workspace:^0.0.1
         version: link:../../db
@@ -838,6 +841,9 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
     devDependencies:
+      '@types/bcryptjs':
+        specifier: ^2.4.6
+        version: 2.4.6
       '@types/node':
         specifier: ^18.11.18
         version: 18.11.18
@@ -2313,24 +2319,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@12.3.4':
     resolution: {integrity: sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@12.3.4':
     resolution: {integrity: sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@12.3.4':
     resolution: {integrity: sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@12.3.4':
     resolution: {integrity: sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==}
@@ -2497,6 +2507,9 @@ packages:
 
   '@types/autocannon@7.9.0':
     resolution: {integrity: sha512-eD8n1TLav/Ps5fx8lOXsoF0io/htFjMmiEu3urzo5QpLw1IT470oubYJjXHLvQCYWoUHEh2j+4Y09YWZ8Nk6oQ==}
+
+  '@types/bcryptjs@2.4.6':
+    resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
 
   '@types/content-type@1.1.5':
     resolution: {integrity: sha512-dgMN+syt1xb7Hk8LU6AODOfPlvz5z1CbXpPuJE5ZrX9STfBOIXF09pEB8N7a97WT9dbngt3ksDCm6GW6yMrxfQ==}
@@ -2813,6 +2826,9 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
@@ -7778,6 +7794,8 @@ snapshots:
     dependencies:
       '@types/node': 18.11.18
 
+  '@types/bcryptjs@2.4.6': {}
+
   '@types/content-type@1.1.5': {}
 
   '@types/cross-spawn@6.0.2':
@@ -8161,6 +8179,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
+
+  bcryptjs@2.4.3: {}
 
   big-integer@1.6.51: {}
 


### PR DESCRIPTION
## Summary

- Replace one-at-a-time `POST /api/v2/users` calls (which hit rate limits) with Auth0's bulk import job API (`POST /api/v2/jobs/users-imports`)
- Hash passwords server-side with bcryptjs before submitting
- Submit all users in a single multipart request, poll for completion
- Validate all Auth0 API responses with zod schemas (no type assertions)
- Add `read:connections` scope check to `testAuth0Credentials`

## Changes

| File | Description |
|------|-------------|
| `packages/services/users/src/modules/users.ts` | Rewrite `importAuth0Users` to use bulk import; add zod schemas; update `testAuth0Credentials` |
| `packages/services/users/package.json` | Add `bcryptjs` + `@types/bcryptjs` |
| `packages/client-admin/src/pages/users.tsx` | Add `read:connections` to required scopes text |

## How it works

1. Fetch `connection_id` for "Username-Password-Authentication"
2. Hash all passwords with bcrypt (10 rounds)
3. Submit bulk import job via multipart form-data
4. Poll `GET /api/v2/jobs/{id}` every 2s (2min timeout)
5. Fetch per-user errors from `GET /api/v2/jobs/{id}/errors`
6. Upsert successful users in local DB
7. Return same result shape as before (no frontend changes needed)

## Test plan

- [ ] Test with invalid token → error
- [ ] Test with token missing `read:connections` scope → descriptive error
- [ ] Import users → single bulk job, no rate limits
- [ ] Verify per-user error reporting (weak password, duplicate email)
- [ ] Verify local DB upsert for successful users