### PR TITLE
Creación del servicio ProgressOverTime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       AUTH0_DOMAIN: ${AUTH0_DOMAIN}
       AUTH0_CLIENT: ${AUTH0_CLIENT}
       AUTH0_SECRET: ${AUTH0_SECRET}
-    command: pnpm --filter=service-progressovertime -r start
+    command: pnpm --filter=service-progress-over-time -r start
   gateway:
     restart: always
     image: pabloszx/learner-model-gql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,16 @@ services:
       AUTH0_CLIENT: ${AUTH0_CLIENT}
       AUTH0_SECRET: ${AUTH0_SECRET}
     command: pnpm --filter=service-actionstopic -r actionstopic
+  progressovertime:
+    restart: always
+    image: pabloszx/learner-model-gql
+    network_mode: host
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
+      AUTH0_CLIENT: ${AUTH0_CLIENT}
+      AUTH0_SECRET: ${AUTH0_SECRET}
+    command: pnpm --filter=service-progressovertime -r start
   gateway:
     restart: always
     image: pabloszx/learner-model-gql

--- a/packages/gateway/src/ez.generated.ts
+++ b/packages/gateway/src/ez.generated.ts
@@ -1660,6 +1660,98 @@ export type PollItemInput = {
   tags?: InputMaybe<Array<Scalars["String"]>>;
 };
 
+/** Temporal granularity of the bucket. */
+export const ProgressOverTimeBucket = {
+  /** Group by day (UTC) */
+  DAY: "DAY",
+  /** Group by month (UTC) */
+  MONTH: "MONTH",
+  /** Group by week (UTC) */
+  WEEK: "WEEK",
+} as const;
+
+export type ProgressOverTimeBucket =
+  (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
+export type ProgressOverTimeGroupInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Current user identifier */
+  currentUserId?: InputMaybe<Scalars["IntID"]>;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** Group identifier */
+  groupId: Scalars["IntID"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+};
+
+/** Point in the time series */
+export type ProgressOverTimePoint = {
+  __typename?: "ProgressOverTimePoint";
+  /** Bucket start time (UTC) */
+  at: Scalars["DateTime"];
+  /** Average level (BKT) over kcCodes */
+  avgLevel?: Maybe<Scalars["Float"]>;
+  /** Number of KCs actually used */
+  nKcsUsed: Scalars["Int"];
+  /** Solo group. Users who contributed to the average */
+  nUsers?: Maybe<Scalars["Int"]>;
+  /** Latest ModelState.updatedAt used within the bucket */
+  snapshotUpdatedAt?: Maybe<Scalars["DateTime"]>;
+};
+
+export type ProgressOverTimeQueries = {
+  __typename?: "ProgressOverTimeQueries";
+  /**
+   * Group series: latest snapshot per user+bucket and then
+   * average across users.
+   */
+  groupBkt: ProgressOverTimeSeries;
+  /**
+   * User series: the last snapshot per bucket within the range is taken and
+   * avgLevel is calculated over kcCodes.
+   */
+  userBkt: ProgressOverTimeSeries;
+};
+
+export type ProgressOverTimeQueriesgroupBktArgs = {
+  input: ProgressOverTimeGroupInput;
+};
+
+export type ProgressOverTimeQueriesuserBktArgs = {
+  input: ProgressOverTimeUserInput;
+};
+
+/** Time series (includes buckets with no data such as null) */
+export type ProgressOverTimeSeries = {
+  __typename?: "ProgressOverTimeSeries";
+  points: Array<ProgressOverTimePoint>;
+};
+
+/** Input: individual progress series (BKT) */
+export type ProgressOverTimeUserInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+  /** User identifier */
+  userId: Scalars["IntID"];
+};
+
 /** Project entity */
 export type Project = {
   __typename?: "Project";
@@ -1884,6 +1976,12 @@ export type Query = {
   poll?: Maybe<Poll>;
   /** Get all polls */
   polls: Array<Poll>;
+  /**
+   * Progress series (BKT) added by user and group.
+   *
+   * Returns points per bucket (DAY/WEEK/MONTH).
+   */
+  progressOverTime: ProgressOverTimeQueries;
   /**
    * Get specified project by either "id" or "code".
    *
@@ -2505,6 +2603,12 @@ export type ResolversTypes = {
   PollInput: PollInput;
   PollItem: ResolverTypeWrapper<PollItem>;
   PollItemInput: PollItemInput;
+  ProgressOverTimeBucket: ProgressOverTimeBucket;
+  ProgressOverTimeGroupInput: ProgressOverTimeGroupInput;
+  ProgressOverTimePoint: ResolverTypeWrapper<ProgressOverTimePoint>;
+  ProgressOverTimeQueries: ResolverTypeWrapper<ProgressOverTimeQueries>;
+  ProgressOverTimeSeries: ResolverTypeWrapper<ProgressOverTimeSeries>;
+  ProgressOverTimeUserInput: ProgressOverTimeUserInput;
   Project: ResolverTypeWrapper<Project>;
   ProjectActionsFilter: ProjectActionsFilter;
   ProjectContentFilter: ProjectContentFilter;
@@ -2636,6 +2740,11 @@ export type ResolversParentTypes = {
   PollInput: PollInput;
   PollItem: PollItem;
   PollItemInput: PollItemInput;
+  ProgressOverTimeGroupInput: ProgressOverTimeGroupInput;
+  ProgressOverTimePoint: ProgressOverTimePoint;
+  ProgressOverTimeQueries: ProgressOverTimeQueries;
+  ProgressOverTimeSeries: ProgressOverTimeSeries;
+  ProgressOverTimeUserInput: ProgressOverTimeUserInput;
   Project: Project;
   ProjectActionsFilter: ProjectActionsFilter;
   ProjectContentFilter: ProjectContentFilter;
@@ -3695,6 +3804,53 @@ export type PollItemResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ProgressOverTimePointResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ProgressOverTimePoint"] = ResolversParentTypes["ProgressOverTimePoint"]
+> = {
+  at?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  avgLevel?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
+  nKcsUsed?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  nUsers?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  snapshotUpdatedAt?: Resolver<
+    Maybe<ResolversTypes["DateTime"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProgressOverTimeQueriesResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ProgressOverTimeQueries"] = ResolversParentTypes["ProgressOverTimeQueries"]
+> = {
+  groupBkt?: Resolver<
+    ResolversTypes["ProgressOverTimeSeries"],
+    ParentType,
+    ContextType,
+    RequireFields<ProgressOverTimeQueriesgroupBktArgs, "input">
+  >;
+  userBkt?: Resolver<
+    ResolversTypes["ProgressOverTimeSeries"],
+    ParentType,
+    ContextType,
+    RequireFields<ProgressOverTimeQueriesuserBktArgs, "input">
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProgressOverTimeSeriesResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ProgressOverTimeSeries"] = ResolversParentTypes["ProgressOverTimeSeries"]
+> = {
+  points?: Resolver<
+    Array<ResolversTypes["ProgressOverTimePoint"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ProjectResolvers<
   ContextType = EZContext,
   ParentType extends ResolversParentTypes["Project"] = ResolversParentTypes["Project"]
@@ -3860,6 +4016,11 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QuerypollsArgs, "ids">
+  >;
+  progressOverTime?: Resolver<
+    ResolversTypes["ProgressOverTimeQueries"],
+    ParentType,
+    ContextType
   >;
   project?: Resolver<
     Maybe<ResolversTypes["Project"]>,
@@ -4083,6 +4244,9 @@ export type Resolvers<ContextType = EZContext> = {
   PageInfo?: PageInfoResolvers<ContextType>;
   Poll?: PollResolvers<ContextType>;
   PollItem?: PollItemResolvers<ContextType>;
+  ProgressOverTimePoint?: ProgressOverTimePointResolvers<ContextType>;
+  ProgressOverTimeQueries?: ProgressOverTimeQueriesResolvers<ContextType>;
+  ProgressOverTimeSeries?: ProgressOverTimeSeriesResolvers<ContextType>;
   Project?: ProjectResolvers<ContextType>;
   ProjectsConnection?: ProjectsConnectionResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/packages/gateway/src/ez.generated.ts
+++ b/packages/gateway/src/ez.generated.ts
@@ -1673,7 +1673,7 @@ export const ProgressOverTimeBucket = {
 export type ProgressOverTimeBucket =
   (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
 export type ProgressOverTimeGroupInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Current user identifier */
   currentUserId?: InputMaybe<Scalars["IntID"]>;
@@ -1736,7 +1736,7 @@ export type ProgressOverTimeSeries = {
 
 /** Input: individual progress series (BKT) */
 export type ProgressOverTimeUserInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Domain identifier */
   domainId: Scalars["IntID"];

--- a/packages/graph/src/rq-gql/graphql.ts
+++ b/packages/graph/src/rq-gql/graphql.ts
@@ -1645,6 +1645,98 @@ export type PollItemInput = {
   tags?: InputMaybe<Array<Scalars["String"]>>;
 };
 
+/** Temporal granularity of the bucket. */
+export const ProgressOverTimeBucket = {
+  /** Group by day (UTC) */
+  Day: "DAY",
+  /** Group by month (UTC) */
+  Month: "MONTH",
+  /** Group by week (UTC) */
+  Week: "WEEK",
+} as const;
+
+export type ProgressOverTimeBucket =
+  (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
+export type ProgressOverTimeGroupInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Current user identifier */
+  currentUserId?: InputMaybe<Scalars["IntID"]>;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** Group identifier */
+  groupId: Scalars["IntID"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+};
+
+/** Point in the time series */
+export type ProgressOverTimePoint = {
+  __typename?: "ProgressOverTimePoint";
+  /** Bucket start time (UTC) */
+  at: Scalars["DateTime"];
+  /** Average level (BKT) over kcCodes */
+  avgLevel?: Maybe<Scalars["Float"]>;
+  /** Number of KCs actually used */
+  nKcsUsed: Scalars["Int"];
+  /** Solo group. Users who contributed to the average */
+  nUsers?: Maybe<Scalars["Int"]>;
+  /** Latest ModelState.updatedAt used within the bucket */
+  snapshotUpdatedAt?: Maybe<Scalars["DateTime"]>;
+};
+
+export type ProgressOverTimeQueries = {
+  __typename?: "ProgressOverTimeQueries";
+  /**
+   * Group series: latest snapshot per user+bucket and then
+   * average across users.
+   */
+  groupBkt: ProgressOverTimeSeries;
+  /**
+   * User series: the last snapshot per bucket within the range is taken and
+   * avgLevel is calculated over kcCodes.
+   */
+  userBkt: ProgressOverTimeSeries;
+};
+
+export type ProgressOverTimeQueriesGroupBktArgs = {
+  input: ProgressOverTimeGroupInput;
+};
+
+export type ProgressOverTimeQueriesUserBktArgs = {
+  input: ProgressOverTimeUserInput;
+};
+
+/** Time series (includes buckets with no data such as null) */
+export type ProgressOverTimeSeries = {
+  __typename?: "ProgressOverTimeSeries";
+  points: Array<ProgressOverTimePoint>;
+};
+
+/** Input: individual progress series (BKT) */
+export type ProgressOverTimeUserInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+  /** User identifier */
+  userId: Scalars["IntID"];
+};
+
 /** Project entity */
 export type Project = {
   __typename?: "Project";
@@ -1869,6 +1961,12 @@ export type Query = {
   poll?: Maybe<Poll>;
   /** Get all polls */
   polls: Array<Poll>;
+  /**
+   * Progress series (BKT) added by user and group.
+   *
+   * Returns points per bucket (DAY/WEEK/MONTH).
+   */
+  progressOverTime: ProgressOverTimeQueries;
   /**
    * Get specified project by either "id" or "code".
    *

--- a/packages/graph/src/rq-gql/graphql.ts
+++ b/packages/graph/src/rq-gql/graphql.ts
@@ -1658,7 +1658,7 @@ export const ProgressOverTimeBucket = {
 export type ProgressOverTimeBucket =
   (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
 export type ProgressOverTimeGroupInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Current user identifier */
   currentUserId?: InputMaybe<Scalars["IntID"]>;
@@ -1721,7 +1721,7 @@ export type ProgressOverTimeSeries = {
 
 /** Input: individual progress series (BKT) */
 export type ProgressOverTimeUserInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Domain identifier */
   domainId: Scalars["IntID"];

--- a/packages/services/list.ts
+++ b/packages/services/list.ts
@@ -8,6 +8,7 @@ export const baseServicesList = {
   model: 3008,
   contentSelection: 3009,
   actionstopic: 3010,
+  progressOverTime: 3011,
 } as const;
 
 export const servicesNames = Object.keys(baseServicesList) as ServiceName[];

--- a/packages/services/progressOverTime/package.json
+++ b/packages/services/progressOverTime/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "service-progress-over-time",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "bob-tsm --node-env=dev --watch=src src/index.ts",
+    "start": "bob-tsm src/index.ts"
+  },
+  "dependencies": {
+    "api-base": "workspace:^0.0.1",
+    "db": "workspace:^0.0.1"
+  }
+}

--- a/packages/services/progressOverTime/schema.gql
+++ b/packages/services/progressOverTime/schema.gql
@@ -1,0 +1,226 @@
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+"Pagination Interface"
+interface Connection {
+  "Pagination information"
+  pageInfo: PageInfo!
+}
+
+"""
+Pagination parameters
+
+Forward pagination parameters can't be mixed with Backward pagination parameters simultaneously
+
+first & after => Forward Pagination
+
+last & before => Backward Pagination
+"""
+input CursorConnectionArgs {
+  """
+  Set the minimum boundary
+
+  Use the "endCursor" field of "pageInfo"
+  """
+  after: IntID
+  """
+  Set the maximum boundary
+
+  Use the "startCursor" field of "pageInfo"
+  """
+  before: IntID
+  """
+  Set the limit of nodes to be fetched
+
+  It can't be more than 50
+  """
+  first: NonNegativeInt
+  """
+  Set the limit of nodes to be fetched
+
+  It can't be more than 50
+  """
+  last: NonNegativeInt
+}
+
+"""
+A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+"""
+scalar DateTime
+
+"""
+A field whose value conforms to the standard internet email address format as specified in RFC822: https://www.w3.org/Protocols/rfc822/.
+"""
+scalar EmailAddress @specifiedBy(url: "https://www.w3.org/Protocols/rfc822/")
+
+"""
+ID that parses as non-negative integer, serializes to string, and can be passed as string or number
+"""
+scalar IntID
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
+
+type Mutation {
+  "Returns 'Hello World!'"
+  hello: String!
+}
+
+"Minimum Entity Information"
+interface Node {
+  "Unique numeric identifier"
+  id: IntID!
+}
+
+"""
+Integers that will have a value of 0 or more.
+"""
+scalar NonNegativeInt
+
+"Order ascendingly or descendingly"
+enum ORDER_BY {
+  ASC
+  DESC
+}
+
+"Paginated related information"
+type PageInfo {
+  "Cursor parameter normally used for forward pagination"
+  endCursor: String
+  """
+  Utility field that returns "true" if a next page can be fetched
+  """
+  hasNextPage: Boolean!
+  """
+  Utility field that returns "true" if a previous page can be fetched
+  """
+  hasPreviousPage: Boolean!
+  "Cursor parameter normally used for backward pagination"
+  startCursor: String
+}
+
+"Temporal granularity of the bucket."
+enum ProgressOverTimeBucket {
+  "Group by day (UTC)"
+  DAY
+  "Group by month (UTC)"
+  MONTH
+  "Group by week (UTC)"
+  WEEK
+}
+
+input ProgressOverTimeGroupInput {
+  "Temporary bucket (default DAY)"
+  bucket: ProgressOverTimeBucket! = DAY
+  "Current user identifier"
+  currentUserId: IntID
+  "Domain identifier"
+  domainId: IntID!
+  "End date of the range (inclusive)"
+  endDate: DateTime!
+  "Group identifier"
+  groupId: IntID!
+  "List of valid KC codes"
+  kcCodes: [String!]!
+  "Projects identifier"
+  projectsIds: [IntID!]!
+  "Initial date of the range (inclusive)"
+  startDate: DateTime!
+}
+
+"Point in the time series"
+type ProgressOverTimePoint {
+  "Bucket start time (UTC)"
+  at: DateTime!
+  "Average level (BKT) over kcCodes"
+  avgLevel: Float
+  "Number of KCs actually used"
+  nKcsUsed: Int!
+  "Solo group. Users who contributed to the average"
+  nUsers: Int
+  "Latest ModelState.updatedAt used within the bucket"
+  snapshotUpdatedAt: DateTime
+}
+
+type ProgressOverTimeQueries {
+  """
+  Group series: latest snapshot per user+bucket and then
+  average across users.
+  """
+  groupBkt(input: ProgressOverTimeGroupInput!): ProgressOverTimeSeries!
+  """
+  User series: the last snapshot per bucket within the range is taken and
+  avgLevel is calculated over kcCodes.
+  """
+  userBkt(input: ProgressOverTimeUserInput!): ProgressOverTimeSeries!
+}
+
+"Time series (includes buckets with no data such as null)"
+type ProgressOverTimeSeries {
+  points: [ProgressOverTimePoint!]!
+}
+
+"Input: individual progress series (BKT)"
+input ProgressOverTimeUserInput {
+  "Temporary bucket (default DAY)"
+  bucket: ProgressOverTimeBucket! = DAY
+  "Domain identifier"
+  domainId: IntID!
+  "End date of the range (inclusive)"
+  endDate: DateTime!
+  "List of valid KC codes"
+  kcCodes: [String!]!
+  "Projects identifier"
+  projectsIds: [IntID!]!
+  "Initial date of the range (inclusive)"
+  startDate: DateTime!
+  "User identifier"
+  userId: IntID!
+}
+
+type Query {
+  "Returns 'Hello World!'"
+  hello: String!
+  """
+  Progress series (BKT) added by user and group.
+
+  Returns points per bucket (DAY/WEEK/MONTH).
+  """
+  progressOverTime: ProgressOverTimeQueries!
+}
+
+type Subscription {
+  "Emits 'Hello World1', 'Hello World2', 'Hello World3', 'Hello World4' and 'Hello World5'"
+  hello: String!
+}
+
+"""
+The javascript `Date` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch.
+"""
+scalar Timestamp
+
+"""
+A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt.
+"""
+scalar URL
+
+"""
+Represents NULL values
+"""
+scalar Void

--- a/packages/services/progressOverTime/schema.gql
+++ b/packages/services/progressOverTime/schema.gql
@@ -126,7 +126,7 @@ enum ProgressOverTimeBucket {
 }
 
 input ProgressOverTimeGroupInput {
-  "Temporary bucket (default DAY)"
+  "Temporal bucket (default DAY)"
   bucket: ProgressOverTimeBucket! = DAY
   "Current user identifier"
   currentUserId: IntID
@@ -178,7 +178,7 @@ type ProgressOverTimeSeries {
 
 "Input: individual progress series (BKT)"
 input ProgressOverTimeUserInput {
-  "Temporary bucket (default DAY)"
+  "Temporal bucket (default DAY)"
   bucket: ProgressOverTimeBucket! = DAY
   "Domain identifier"
   domainId: IntID!

--- a/packages/services/progressOverTime/src/app.ts
+++ b/packages/services/progressOverTime/src/app.ts
@@ -1,0 +1,8 @@
+import { buildApp } from "./ez";
+
+export const ezApp = buildApp({
+  async prepare() {
+    await import("./modules/index");
+  },
+});
+export * from "./ez";

--- a/packages/services/progressOverTime/src/ez.generated.ts
+++ b/packages/services/progressOverTime/src/ez.generated.ts
@@ -1,0 +1,583 @@
+import type {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from "graphql";
+import type { EZContext } from "graphql-ez";
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) =>
+  | Promise<import("graphql-ez").DeepPartial<TResult>>
+  | import("graphql-ez").DeepPartial<TResult>;
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>;
+};
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
+  DateTime: string | Date;
+  /** A field whose value conforms to the standard internet email address format as specified in RFC822: https://www.w3.org/Protocols/rfc822/. */
+  EmailAddress: string;
+  /** ID that parses as non-negative integer, serializes to string, and can be passed as string or number */
+  IntID: number;
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSON: unknown;
+  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSONObject: any;
+  /** Integers that will have a value of 0 or more. */
+  NonNegativeInt: number;
+  /** The javascript `Date` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch. */
+  Timestamp: Date;
+  /** A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt. */
+  URL: string;
+  /** Represents NULL values */
+  Void: unknown;
+};
+
+/** Pagination Interface */
+export type Connection = {
+  /** Pagination information */
+  pageInfo: PageInfo;
+};
+
+/**
+ * Pagination parameters
+ *
+ * Forward pagination parameters can't be mixed with Backward pagination parameters simultaneously
+ *
+ * first & after => Forward Pagination
+ *
+ * last & before => Backward Pagination
+ */
+export type CursorConnectionArgs = {
+  /**
+   * Set the minimum boundary
+   *
+   * Use the "endCursor" field of "pageInfo"
+   */
+  after?: InputMaybe<Scalars["IntID"]>;
+  /**
+   * Set the maximum boundary
+   *
+   * Use the "startCursor" field of "pageInfo"
+   */
+  before?: InputMaybe<Scalars["IntID"]>;
+  /**
+   * Set the limit of nodes to be fetched
+   *
+   * It can't be more than 50
+   */
+  first?: InputMaybe<Scalars["NonNegativeInt"]>;
+  /**
+   * Set the limit of nodes to be fetched
+   *
+   * It can't be more than 50
+   */
+  last?: InputMaybe<Scalars["NonNegativeInt"]>;
+};
+
+export type Mutation = {
+  __typename?: "Mutation";
+  /** Returns 'Hello World!' */
+  hello: Scalars["String"];
+};
+
+/** Minimum Entity Information */
+export type Node = {
+  /** Unique numeric identifier */
+  id: Scalars["IntID"];
+};
+
+/** Order ascendingly or descendingly */
+export const ORDER_BY = {
+  ASC: "ASC",
+  DESC: "DESC",
+} as const;
+
+export type ORDER_BY = (typeof ORDER_BY)[keyof typeof ORDER_BY];
+/** Paginated related information */
+export type PageInfo = {
+  __typename?: "PageInfo";
+  /** Cursor parameter normally used for forward pagination */
+  endCursor?: Maybe<Scalars["String"]>;
+  /** Utility field that returns "true" if a next page can be fetched */
+  hasNextPage: Scalars["Boolean"];
+  /** Utility field that returns "true" if a previous page can be fetched */
+  hasPreviousPage: Scalars["Boolean"];
+  /** Cursor parameter normally used for backward pagination */
+  startCursor?: Maybe<Scalars["String"]>;
+};
+
+/** Temporal granularity of the bucket. */
+export const ProgressOverTimeBucket = {
+  /** Group by day (UTC) */
+  DAY: "DAY",
+  /** Group by month (UTC) */
+  MONTH: "MONTH",
+  /** Group by week (UTC) */
+  WEEK: "WEEK",
+} as const;
+
+export type ProgressOverTimeBucket =
+  (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
+export type ProgressOverTimeGroupInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Current user identifier */
+  currentUserId?: InputMaybe<Scalars["IntID"]>;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** Group identifier */
+  groupId: Scalars["IntID"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+};
+
+/** Point in the time series */
+export type ProgressOverTimePoint = {
+  __typename?: "ProgressOverTimePoint";
+  /** Bucket start time (UTC) */
+  at: Scalars["DateTime"];
+  /** Average level (BKT) over kcCodes */
+  avgLevel?: Maybe<Scalars["Float"]>;
+  /** Number of KCs actually used */
+  nKcsUsed: Scalars["Int"];
+  /** Solo group. Users who contributed to the average */
+  nUsers?: Maybe<Scalars["Int"]>;
+  /** Latest ModelState.updatedAt used within the bucket */
+  snapshotUpdatedAt?: Maybe<Scalars["DateTime"]>;
+};
+
+export type ProgressOverTimeQueries = {
+  __typename?: "ProgressOverTimeQueries";
+  /**
+   * Group series: latest snapshot per user+bucket and then
+   * average across users.
+   */
+  groupBkt: ProgressOverTimeSeries;
+  /**
+   * User series: the last snapshot per bucket within the range is taken and
+   * avgLevel is calculated over kcCodes.
+   */
+  userBkt: ProgressOverTimeSeries;
+};
+
+export type ProgressOverTimeQueriesgroupBktArgs = {
+  input: ProgressOverTimeGroupInput;
+};
+
+export type ProgressOverTimeQueriesuserBktArgs = {
+  input: ProgressOverTimeUserInput;
+};
+
+/** Time series (includes buckets with no data such as null) */
+export type ProgressOverTimeSeries = {
+  __typename?: "ProgressOverTimeSeries";
+  points: Array<ProgressOverTimePoint>;
+};
+
+/** Input: individual progress series (BKT) */
+export type ProgressOverTimeUserInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+  /** User identifier */
+  userId: Scalars["IntID"];
+};
+
+export type Query = {
+  __typename?: "Query";
+  /** Returns 'Hello World!' */
+  hello: Scalars["String"];
+  /**
+   * Progress series (BKT) added by user and group.
+   *
+   * Returns points per bucket (DAY/WEEK/MONTH).
+   */
+  progressOverTime: ProgressOverTimeQueries;
+};
+
+export type Subscription = {
+  __typename?: "Subscription";
+  /** Emits 'Hello World1', 'Hello World2', 'Hello World3', 'Hello World4' and 'Hello World5' */
+  hello: Scalars["String"];
+};
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Connection: never;
+  CursorConnectionArgs: CursorConnectionArgs;
+  DateTime: ResolverTypeWrapper<Scalars["DateTime"]>;
+  EmailAddress: ResolverTypeWrapper<Scalars["EmailAddress"]>;
+  IntID: ResolverTypeWrapper<Scalars["IntID"]>;
+  JSON: ResolverTypeWrapper<Scalars["JSON"]>;
+  JSONObject: ResolverTypeWrapper<Scalars["JSONObject"]>;
+  Mutation: ResolverTypeWrapper<{}>;
+  String: ResolverTypeWrapper<Scalars["String"]>;
+  Node: never;
+  NonNegativeInt: ResolverTypeWrapper<Scalars["NonNegativeInt"]>;
+  ORDER_BY: ORDER_BY;
+  PageInfo: ResolverTypeWrapper<PageInfo>;
+  Boolean: ResolverTypeWrapper<Scalars["Boolean"]>;
+  ProgressOverTimeBucket: ProgressOverTimeBucket;
+  ProgressOverTimeGroupInput: ProgressOverTimeGroupInput;
+  ProgressOverTimePoint: ResolverTypeWrapper<ProgressOverTimePoint>;
+  Float: ResolverTypeWrapper<Scalars["Float"]>;
+  Int: ResolverTypeWrapper<Scalars["Int"]>;
+  ProgressOverTimeQueries: ResolverTypeWrapper<ProgressOverTimeQueries>;
+  ProgressOverTimeSeries: ResolverTypeWrapper<ProgressOverTimeSeries>;
+  ProgressOverTimeUserInput: ProgressOverTimeUserInput;
+  Query: ResolverTypeWrapper<{}>;
+  Subscription: ResolverTypeWrapper<{}>;
+  Timestamp: ResolverTypeWrapper<Scalars["Timestamp"]>;
+  URL: ResolverTypeWrapper<Scalars["URL"]>;
+  Void: ResolverTypeWrapper<Scalars["Void"]>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Connection: never;
+  CursorConnectionArgs: CursorConnectionArgs;
+  DateTime: Scalars["DateTime"];
+  EmailAddress: Scalars["EmailAddress"];
+  IntID: Scalars["IntID"];
+  JSON: Scalars["JSON"];
+  JSONObject: Scalars["JSONObject"];
+  Mutation: {};
+  String: Scalars["String"];
+  Node: never;
+  NonNegativeInt: Scalars["NonNegativeInt"];
+  PageInfo: PageInfo;
+  Boolean: Scalars["Boolean"];
+  ProgressOverTimeGroupInput: ProgressOverTimeGroupInput;
+  ProgressOverTimePoint: ProgressOverTimePoint;
+  Float: Scalars["Float"];
+  Int: Scalars["Int"];
+  ProgressOverTimeQueries: ProgressOverTimeQueries;
+  ProgressOverTimeSeries: ProgressOverTimeSeries;
+  ProgressOverTimeUserInput: ProgressOverTimeUserInput;
+  Query: {};
+  Subscription: {};
+  Timestamp: Scalars["Timestamp"];
+  URL: Scalars["URL"];
+  Void: Scalars["Void"];
+};
+
+export type ConnectionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Connection"] = ResolversParentTypes["Connection"]
+> = {
+  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+  pageInfo?: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+};
+
+export interface DateTimeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["DateTime"], any> {
+  name: "DateTime";
+}
+
+export interface EmailAddressScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["EmailAddress"], any> {
+  name: "EmailAddress";
+}
+
+export interface IntIDScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["IntID"], any> {
+  name: "IntID";
+}
+
+export interface JSONScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["JSON"], any> {
+  name: "JSON";
+}
+
+export interface JSONObjectScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["JSONObject"], any> {
+  name: "JSONObject";
+}
+
+export type MutationResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Mutation"] = ResolversParentTypes["Mutation"]
+> = {
+  hello?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+};
+
+export type NodeResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Node"] = ResolversParentTypes["Node"]
+> = {
+  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["IntID"], ParentType, ContextType>;
+};
+
+export interface NonNegativeIntScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["NonNegativeInt"], any> {
+  name: "NonNegativeInt";
+}
+
+export type PageInfoResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["PageInfo"] = ResolversParentTypes["PageInfo"]
+> = {
+  endCursor?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  hasNextPage?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  hasPreviousPage?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  startCursor?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProgressOverTimePointResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ProgressOverTimePoint"] = ResolversParentTypes["ProgressOverTimePoint"]
+> = {
+  at?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  avgLevel?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
+  nKcsUsed?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  nUsers?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  snapshotUpdatedAt?: Resolver<
+    Maybe<ResolversTypes["DateTime"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProgressOverTimeQueriesResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ProgressOverTimeQueries"] = ResolversParentTypes["ProgressOverTimeQueries"]
+> = {
+  groupBkt?: Resolver<
+    ResolversTypes["ProgressOverTimeSeries"],
+    ParentType,
+    ContextType,
+    RequireFields<ProgressOverTimeQueriesgroupBktArgs, "input">
+  >;
+  userBkt?: Resolver<
+    ResolversTypes["ProgressOverTimeSeries"],
+    ParentType,
+    ContextType,
+    RequireFields<ProgressOverTimeQueriesuserBktArgs, "input">
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProgressOverTimeSeriesResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["ProgressOverTimeSeries"] = ResolversParentTypes["ProgressOverTimeSeries"]
+> = {
+  points?: Resolver<
+    Array<ResolversTypes["ProgressOverTimePoint"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type QueryResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Query"] = ResolversParentTypes["Query"]
+> = {
+  hello?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  progressOverTime?: Resolver<
+    ResolversTypes["ProgressOverTimeQueries"],
+    ParentType,
+    ContextType
+  >;
+};
+
+export type SubscriptionResolvers<
+  ContextType = EZContext,
+  ParentType extends ResolversParentTypes["Subscription"] = ResolversParentTypes["Subscription"]
+> = {
+  hello?: SubscriptionResolver<
+    ResolversTypes["String"],
+    "hello",
+    ParentType,
+    ContextType
+  >;
+};
+
+export interface TimestampScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["Timestamp"], any> {
+  name: "Timestamp";
+}
+
+export interface URLScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["URL"], any> {
+  name: "URL";
+}
+
+export interface VoidScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["Void"], any> {
+  name: "Void";
+}
+
+export type Resolvers<ContextType = EZContext> = {
+  Connection?: ConnectionResolvers<ContextType>;
+  DateTime?: GraphQLScalarType;
+  EmailAddress?: GraphQLScalarType;
+  IntID?: GraphQLScalarType;
+  JSON?: GraphQLScalarType;
+  JSONObject?: GraphQLScalarType;
+  Mutation?: MutationResolvers<ContextType>;
+  Node?: NodeResolvers<ContextType>;
+  NonNegativeInt?: GraphQLScalarType;
+  PageInfo?: PageInfoResolvers<ContextType>;
+  ProgressOverTimePoint?: ProgressOverTimePointResolvers<ContextType>;
+  ProgressOverTimeQueries?: ProgressOverTimeQueriesResolvers<ContextType>;
+  ProgressOverTimeSeries?: ProgressOverTimeSeriesResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  Subscription?: SubscriptionResolvers<ContextType>;
+  Timestamp?: GraphQLScalarType;
+  URL?: GraphQLScalarType;
+  Void?: GraphQLScalarType;
+};
+
+declare module "graphql-ez" {
+  interface EZResolvers extends Resolvers<import("graphql-ez").EZContext> {}
+}

--- a/packages/services/progressOverTime/src/ez.generated.ts
+++ b/packages/services/progressOverTime/src/ez.generated.ts
@@ -140,7 +140,7 @@ export const ProgressOverTimeBucket = {
 export type ProgressOverTimeBucket =
   (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
 export type ProgressOverTimeGroupInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Current user identifier */
   currentUserId?: InputMaybe<Scalars["IntID"]>;
@@ -203,7 +203,7 @@ export type ProgressOverTimeSeries = {
 
 /** Input: individual progress series (BKT) */
 export type ProgressOverTimeUserInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Domain identifier */
   domainId: Scalars["IntID"];

--- a/packages/services/progressOverTime/src/ez.ts
+++ b/packages/services/progressOverTime/src/ez.ts
@@ -1,0 +1,11 @@
+import { CreateApp } from "@graphql-ez/fastify";
+import { ezServicePreset } from "api-base";
+
+// This created the new GraphQL EZ instance, re-using a service preset with tools like GraphQL Codegen, GraphQL Altair and GraphQL Voyager
+export const { buildApp, gql, registerModule } = CreateApp({
+  ez: {
+    preset: ezServicePreset,
+  },
+});
+
+export * from "api-base";

--- a/packages/services/progressOverTime/src/index.ts
+++ b/packages/services/progressOverTime/src/index.ts
@@ -1,0 +1,21 @@
+import { baseServicesList, logger, pubSub, smartListen } from "api-base";
+import Fastify from "fastify";
+import { ezApp } from "./app";
+
+const app = Fastify({
+  logger,
+  pluginTimeout: 30000,
+});
+
+app.register(ezApp.fastifyPlugin);
+
+app.ready(async (err) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  await smartListen(app, baseServicesList.progressOverTime);
+
+  pubSub.publish("updateGateway", "progressOverTime");
+});

--- a/packages/services/progressOverTime/src/modules/index.ts
+++ b/packages/services/progressOverTime/src/modules/index.ts
@@ -1,0 +1,1 @@
+export * from "./progressOverTime";

--- a/packages/services/progressOverTime/src/modules/progressOverTime.ts
+++ b/packages/services/progressOverTime/src/modules/progressOverTime.ts
@@ -1,6 +1,5 @@
 import { gql, registerModule } from "../ez";
-import type { EZContext } from "graphql-ez";
-import type { PrismaNS, PrismaClient } from "api-base";
+import type { PrismaNS } from "api-base";
 
 import type {
   Resolvers,
@@ -11,8 +10,6 @@ import type {
 import { addBucket, asBucket, startOfBucket, toKey } from "./utils/bucket";
 import { avgLevelFromBktJson } from "./utils/bktModel";
 import { iterateModelStatesBkt } from "./utils/modelStateIterator";
-
-type Context = EZContext & { prisma: PrismaClient };
 
 export const progressOverTimeModule = registerModule(
   gql`
@@ -45,7 +42,7 @@ export const progressOverTimeModule = registerModule(
       startDate: DateTime!
       "End date of the range (inclusive)"
       endDate: DateTime!
-      "Temporary bucket (default DAY)"
+      "Temporal bucket (default DAY)"
       bucket: ProgressOverTimeBucket! = DAY
       "List of valid KC codes"
       kcCodes: [String!]!
@@ -64,7 +61,7 @@ export const progressOverTimeModule = registerModule(
       startDate: DateTime!
       "End date of the range (inclusive)"
       endDate: DateTime!
-      "Temporary bucket (default DAY)"
+      "Temporal bucket (default DAY)"
       bucket: ProgressOverTimeBucket! = DAY
       "List of valid KC codes"
       kcCodes: [String!]!
@@ -105,7 +102,8 @@ export const progressOverTimeModule = registerModule(
     dirname: import.meta.url,
     resolvers: {
       Query: {
-        progressOverTime() {
+        async progressOverTime(_root, _args, { authorization }) {
+          await authorization.expectUser;
           return {};
         },
       },
@@ -113,7 +111,7 @@ export const progressOverTimeModule = registerModule(
         async userBkt(
           _root,
           { input }: ProgressOverTimeQueriesuserBktArgs,
-          { prisma }: Context
+          { prisma }
         ) {
           const bucket = asBucket(input.bucket);
           const startDate = new Date(input.startDate);
@@ -190,7 +188,7 @@ export const progressOverTimeModule = registerModule(
         async groupBkt(
           _root,
           { input }: ProgressOverTimeQueriesgroupBktArgs,
-          { prisma }: Context
+          { prisma }
         ) {
           const bucket = asBucket(input.bucket);
 
@@ -331,6 +329,6 @@ export const progressOverTimeModule = registerModule(
           return { points };
         },
       },
-    } satisfies Resolvers<Context>,
+    } satisfies Resolvers,
   }
 );

--- a/packages/services/progressOverTime/src/modules/progressOverTime.ts
+++ b/packages/services/progressOverTime/src/modules/progressOverTime.ts
@@ -1,0 +1,336 @@
+import { gql, registerModule } from "../ez";
+import type { EZContext } from "graphql-ez";
+import type { PrismaNS, PrismaClient } from "api-base";
+
+import type {
+  Resolvers,
+  ProgressOverTimeQueriesuserBktArgs,
+  ProgressOverTimeQueriesgroupBktArgs,
+} from "../ez.generated";
+
+import { addBucket, asBucket, startOfBucket, toKey } from "./utils/bucket";
+import { avgLevelFromBktJson } from "./utils/bktModel";
+import { iterateModelStatesBkt } from "./utils/modelStateIterator";
+
+type Context = EZContext & { prisma: PrismaClient };
+
+export const progressOverTimeModule = registerModule(
+  gql`
+    extend type Query {
+      """
+      Progress series (BKT) added by user and group.
+
+      Returns points per bucket (DAY/WEEK/MONTH).
+      """
+      progressOverTime: ProgressOverTimeQueries!
+    }
+    "Temporal granularity of the bucket."
+    enum ProgressOverTimeBucket {
+      "Group by day (UTC)"
+      DAY
+      "Group by week (UTC)"
+      WEEK
+      "Group by month (UTC)"
+      MONTH
+    }
+    "Input: individual progress series (BKT)"
+    input ProgressOverTimeUserInput {
+      "Projects identifier"
+      projectsIds: [IntID!]!
+      "User identifier"
+      userId: IntID!
+      "Domain identifier"
+      domainId: IntID!
+      "Initial date of the range (inclusive)"
+      startDate: DateTime!
+      "End date of the range (inclusive)"
+      endDate: DateTime!
+      "Temporary bucket (default DAY)"
+      bucket: ProgressOverTimeBucket! = DAY
+      "List of valid KC codes"
+      kcCodes: [String!]!
+    }
+
+    input ProgressOverTimeGroupInput {
+      "Projects identifier"
+      projectsIds: [IntID!]!
+      "Group identifier"
+      groupId: IntID!
+      "Current user identifier"
+      currentUserId: IntID
+      "Domain identifier"
+      domainId: IntID!
+      "Initial date of the range (inclusive)"
+      startDate: DateTime!
+      "End date of the range (inclusive)"
+      endDate: DateTime!
+      "Temporary bucket (default DAY)"
+      bucket: ProgressOverTimeBucket! = DAY
+      "List of valid KC codes"
+      kcCodes: [String!]!
+    }
+    "Point in the time series"
+    type ProgressOverTimePoint {
+      "Bucket start time (UTC)"
+      at: DateTime!
+      "Latest ModelState.updatedAt used within the bucket"
+      snapshotUpdatedAt: DateTime
+      "Average level (BKT) over kcCodes"
+      avgLevel: Float
+      "Number of KCs actually used"
+      nKcsUsed: Int!
+      "Solo group. Users who contributed to the average"
+      nUsers: Int
+    }
+    "Time series (includes buckets with no data such as null)"
+    type ProgressOverTimeSeries {
+      points: [ProgressOverTimePoint!]!
+    }
+
+    type ProgressOverTimeQueries {
+      """
+      User series: the last snapshot per bucket within the range is taken and
+      avgLevel is calculated over kcCodes.
+      """
+      userBkt(input: ProgressOverTimeUserInput!): ProgressOverTimeSeries!
+      """
+      Group series: latest snapshot per user+bucket and then
+      average across users.
+      """
+      groupBkt(input: ProgressOverTimeGroupInput!): ProgressOverTimeSeries!
+    }
+  `,
+  {
+    id: "ProgressOverTime",
+    dirname: import.meta.url,
+    resolvers: {
+      Query: {
+        progressOverTime() {
+          return {};
+        },
+      },
+      ProgressOverTimeQueries: {
+        async userBkt(
+          _root,
+          { input }: ProgressOverTimeQueriesuserBktArgs,
+          { prisma }: Context
+        ) {
+          const bucket = asBucket(input.bucket);
+          const startDate = new Date(input.startDate);
+          const endDate = new Date(input.endDate);
+
+          const allowed = new Set<string>(input.kcCodes ?? []);
+
+          const lastByBucket = new Map<
+            string,
+            {
+              snapshotUpdatedAt: Date;
+              avgLevel: number | null;
+              nKcsUsed: number;
+            }
+          >();
+
+          const where: PrismaNS.ModelStateWhereInput = {
+            userId: input.userId,
+            domainId: input.domainId,
+            type: "BKT",
+            updatedAt: { gte: input.startDate, lte: input.endDate },
+            user: {
+              projects: {
+                some: {
+                  id: { in: input.projectsIds },
+                },
+              },
+            },
+          };
+
+          await iterateModelStatesBkt(prisma, where, (row) => {
+            const key = toKey(startOfBucket(row.updatedAt, bucket));
+
+            const prev = lastByBucket.get(key);
+            if (prev && prev.snapshotUpdatedAt >= row.updatedAt) return;
+            const { avgLevel, nKcsUsed } = avgLevelFromBktJson(
+              row.json,
+              allowed
+            );
+            lastByBucket.set(key, {
+              snapshotUpdatedAt: row.updatedAt,
+              avgLevel,
+              nKcsUsed,
+            });
+          });
+          const start = startOfBucket(startDate, bucket);
+          const end = startOfBucket(endDate, bucket);
+
+          const points: Array<{
+            at: Date;
+            snapshotUpdatedAt: Date | null;
+            avgLevel: number | null;
+            nKcsUsed: number;
+            nUsers: number | null;
+          }> = [];
+
+          for (
+            let cursor = new Date(start);
+            cursor <= end;
+            cursor = addBucket(cursor, bucket)
+          ) {
+            const snap = lastByBucket.get(toKey(cursor));
+            points.push({
+              at: new Date(cursor),
+              snapshotUpdatedAt: snap?.snapshotUpdatedAt ?? null,
+              avgLevel: snap?.avgLevel ?? null,
+              nKcsUsed: snap?.nKcsUsed ?? 0,
+              nUsers: null,
+            });
+          }
+          return { points };
+        },
+
+        async groupBkt(
+          _root,
+          { input }: ProgressOverTimeQueriesgroupBktArgs,
+          { prisma }: Context
+        ) {
+          const bucket = asBucket(input.bucket);
+
+          const startDate = new Date(input.startDate);
+          const endDate = new Date(input.endDate);
+
+          const allowed = new Set<string>(input.kcCodes ?? []);
+
+          const group = (await prisma.group.findUnique({
+            where: { id: input.groupId },
+            select: { users: { select: { id: true } } },
+          })) as { users: Array<{ id: number }> } | null;
+
+          const userIds: number[] = (group?.users ?? [])
+            .map((u) => u.id)
+            .filter((id) =>
+              input.currentUserId ? id !== input.currentUserId : true
+            );
+
+          const lastByUserBucket = new Map<
+            string,
+            { updatedAt: Date; avgLevel: number | null; nKcsUsed: number }
+          >();
+
+          const aggByBucket = new Map<
+            string,
+            {
+              sumLevel: number;
+              nUsersLevel: number;
+              sumKcsUsed: number;
+              snapshotUpdatedAt: Date | null;
+            }
+          >();
+
+          const ensureAgg = (bucketKey: string) => {
+            const ex = aggByBucket.get(bucketKey);
+            if (ex) return ex;
+            const init = {
+              sumLevel: 0,
+              nUsersLevel: 0,
+              sumKcsUsed: 0,
+              snapshotUpdatedAt: null as Date | null,
+            };
+            aggByBucket.set(bucketKey, init);
+            return init;
+          };
+
+          const applyOverwrite = (
+            userId: number,
+            bucketKey: string,
+            updatedAt: Date,
+            avgLevel: number | null,
+            nKcsUsed: number
+          ) => {
+            const key = `${userId}|${bucketKey}`;
+            const prev = lastByUserBucket.get(key);
+            if (prev && prev.updatedAt >= updatedAt) return;
+
+            const agg = ensureAgg(bucketKey);
+
+            if (prev && typeof prev.avgLevel === "number") {
+              agg.sumLevel -= prev.avgLevel;
+              agg.nUsersLevel -= 1;
+              agg.sumKcsUsed -= prev.nKcsUsed;
+            }
+
+            if (typeof avgLevel === "number") {
+              agg.sumLevel += avgLevel;
+              agg.nUsersLevel += 1;
+              agg.sumKcsUsed += nKcsUsed;
+            }
+
+            if (!agg.snapshotUpdatedAt || updatedAt > agg.snapshotUpdatedAt) {
+              agg.snapshotUpdatedAt = updatedAt;
+            }
+
+            lastByUserBucket.set(key, { updatedAt, avgLevel, nKcsUsed });
+          };
+
+          const where: PrismaNS.ModelStateWhereInput = {
+            userId: { in: userIds },
+            domainId: input.domainId,
+            type: "BKT",
+            updatedAt: { gte: input.startDate, lte: input.endDate },
+            user: {
+              projects: {
+                some: {
+                  id: { in: input.projectsIds },
+                },
+              },
+            },
+          };
+
+          await iterateModelStatesBkt(prisma, where, (row) => {
+            const bucketKey = toKey(startOfBucket(row.updatedAt, bucket));
+            const { avgLevel, nKcsUsed } = avgLevelFromBktJson(
+              row.json,
+              allowed
+            );
+            applyOverwrite(
+              row.userId,
+              bucketKey,
+              row.updatedAt,
+              avgLevel,
+              nKcsUsed
+            );
+          });
+
+          const start = startOfBucket(startDate, bucket);
+          const end = startOfBucket(endDate, bucket);
+
+          const points: Array<{
+            at: Date;
+            snapshotUpdatedAt: Date | null;
+            avgLevel: number | null;
+            nKcsUsed: number;
+            nUsers: number;
+          }> = [];
+
+          for (
+            let cursor = new Date(start);
+            cursor <= end;
+            cursor = addBucket(cursor, bucket)
+          ) {
+            const agg = aggByBucket.get(toKey(cursor));
+            points.push({
+              at: new Date(cursor),
+              snapshotUpdatedAt: agg?.snapshotUpdatedAt ?? null,
+              avgLevel:
+                agg && agg.nUsersLevel ? agg.sumLevel / agg.nUsersLevel : null,
+              nKcsUsed:
+                agg && agg.nUsersLevel
+                  ? Math.round(agg.sumKcsUsed / agg.nUsersLevel)
+                  : 0,
+              nUsers: agg?.nUsersLevel ?? 0,
+            });
+          }
+          return { points };
+        },
+      },
+    } satisfies Resolvers<Context>,
+  }
+);

--- a/packages/services/progressOverTime/src/modules/utils/bktModel.ts
+++ b/packages/services/progressOverTime/src/modules/utils/bktModel.ts
@@ -1,0 +1,28 @@
+import type { PrismaNS } from "api-base";
+
+type KcState = { level?: number };
+type ModelJson = Record<string, KcState>;
+
+export function avgLevelFromBktJson(
+  json: PrismaNS.JsonValue,
+  allowed: Set<string>
+): { avgLevel: number | null; nKcsUsed: number } {
+  if (!json || typeof json !== "object" || Array.isArray(json)) {
+    return { avgLevel: null, nKcsUsed: 0 };
+  }
+  const obj = json as unknown as ModelJson;
+  let sum = 0;
+  let n = 0;
+
+  for (const [kc, v] of Object.entries(obj)) {
+    if (!kc) continue;
+    if (!allowed.has(kc)) continue;
+
+    const level = v?.level;
+    if (typeof level !== "number" || Number.isNaN(level)) continue;
+
+    sum += level;
+    n += 1;
+  }
+  return { avgLevel: n ? sum / n : null, nKcsUsed: n };
+}

--- a/packages/services/progressOverTime/src/modules/utils/bucket.ts
+++ b/packages/services/progressOverTime/src/modules/utils/bucket.ts
@@ -1,0 +1,47 @@
+type Bucket = "DAY" | "WEEK" | "MONTH";
+
+export function asBucket(bucket: unknown): Bucket {
+  if (bucket === "DAY" || bucket === "WEEK" || bucket === "MONTH") {
+    return bucket;
+  }
+  return "DAY";
+}
+
+export function startOfBucket(date: Date, bucket: Bucket): Date {
+  const d = new Date(date);
+  if (bucket === "DAY") {
+    d.setUTCHours(0, 0, 0, 0);
+    return d;
+  }
+  if (bucket === "WEEK") {
+    const day = d.getUTCDay();
+    const diff = (day + 6) % 7;
+    d.setUTCDate(d.getUTCDate() - diff);
+    d.setUTCHours(0, 0, 0, 0);
+    return d;
+  }
+  //month
+  d.setUTCDate(1);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+export function addBucket(date: Date, bucket: Bucket): Date {
+  const d = new Date(date);
+
+  if (bucket === "DAY") {
+    d.setUTCDate(d.getUTCDate() + 1);
+    return d;
+  }
+  if (bucket === "WEEK") {
+    d.setUTCDate(d.getUTCDate() + 7);
+    return d;
+  }
+  //month
+  d.setUTCMonth(d.getUTCMonth() + 1);
+  return d;
+}
+
+export function toKey(date: Date): string {
+  return date.toISOString();
+}

--- a/packages/services/progressOverTime/src/modules/utils/modelStateIterator.ts
+++ b/packages/services/progressOverTime/src/modules/utils/modelStateIterator.ts
@@ -1,4 +1,4 @@
-import type { PrismaNS } from "api-base";
+import type { PrismaNS, PrismaClient } from "api-base";
 
 const BATCH_SIZE = 1000;
 
@@ -10,7 +10,7 @@ export type ModelStateRow = {
 };
 
 export async function iterateModelStatesBkt(
-  prisma: any,
+  prisma: PrismaClient,
   where: PrismaNS.ModelStateWhereInput,
   onRow: (row: ModelStateRow) => void | Promise<void>
 ) {

--- a/packages/services/progressOverTime/src/modules/utils/modelStateIterator.ts
+++ b/packages/services/progressOverTime/src/modules/utils/modelStateIterator.ts
@@ -1,0 +1,39 @@
+import type { PrismaNS } from "api-base";
+
+const BATCH_SIZE = 1000;
+
+export type ModelStateRow = {
+  id: number;
+  userId: number;
+  updatedAt: Date;
+  json: PrismaNS.JsonValue;
+};
+
+export async function iterateModelStatesBkt(
+  prisma: any,
+  where: PrismaNS.ModelStateWhereInput,
+  onRow: (row: ModelStateRow) => void | Promise<void>
+) {
+  let cursorId: number | undefined;
+
+  while (true) {
+    const batch = (await prisma.modelState.findMany({
+      take: BATCH_SIZE,
+      ...(cursorId ? { cursor: { id: cursorId }, skip: 1 } : {}),
+      where,
+      orderBy: { id: "asc" },
+      select: {
+        id: true,
+        userId: true,
+        updatedAt: true,
+        json: true,
+      },
+    })) as ModelStateRow[];
+
+    if (batch.length === 0) break;
+    for (const row of batch) await onRow(row);
+
+    cursorId = batch.at(-1)?.id;
+    if (!cursorId) break;
+  }
+}

--- a/packages/services/progressOverTime/tsconfig.json
+++ b/packages/services/progressOverTime/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["**/*"],
+  "exclude": ["**/node_modules"]
+}

--- a/packages/testing/src/generated/graphql.ts
+++ b/packages/testing/src/generated/graphql.ts
@@ -1658,7 +1658,7 @@ export const ProgressOverTimeBucket = {
 export type ProgressOverTimeBucket =
   (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
 export type ProgressOverTimeGroupInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Current user identifier */
   currentUserId?: InputMaybe<Scalars["IntID"]>;
@@ -1721,7 +1721,7 @@ export type ProgressOverTimeSeries = {
 
 /** Input: individual progress series (BKT) */
 export type ProgressOverTimeUserInput = {
-  /** Temporary bucket (default DAY) */
+  /** Temporal bucket (default DAY) */
   bucket?: ProgressOverTimeBucket;
   /** Domain identifier */
   domainId: Scalars["IntID"];

--- a/packages/testing/src/generated/graphql.ts
+++ b/packages/testing/src/generated/graphql.ts
@@ -1645,6 +1645,98 @@ export type PollItemInput = {
   tags?: InputMaybe<Array<Scalars["String"]>>;
 };
 
+/** Temporal granularity of the bucket. */
+export const ProgressOverTimeBucket = {
+  /** Group by day (UTC) */
+  DAY: "DAY",
+  /** Group by month (UTC) */
+  MONTH: "MONTH",
+  /** Group by week (UTC) */
+  WEEK: "WEEK",
+} as const;
+
+export type ProgressOverTimeBucket =
+  (typeof ProgressOverTimeBucket)[keyof typeof ProgressOverTimeBucket];
+export type ProgressOverTimeGroupInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Current user identifier */
+  currentUserId?: InputMaybe<Scalars["IntID"]>;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** Group identifier */
+  groupId: Scalars["IntID"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+};
+
+/** Point in the time series */
+export type ProgressOverTimePoint = {
+  __typename?: "ProgressOverTimePoint";
+  /** Bucket start time (UTC) */
+  at: Scalars["DateTime"];
+  /** Average level (BKT) over kcCodes */
+  avgLevel?: Maybe<Scalars["Float"]>;
+  /** Number of KCs actually used */
+  nKcsUsed: Scalars["Int"];
+  /** Solo group. Users who contributed to the average */
+  nUsers?: Maybe<Scalars["Int"]>;
+  /** Latest ModelState.updatedAt used within the bucket */
+  snapshotUpdatedAt?: Maybe<Scalars["DateTime"]>;
+};
+
+export type ProgressOverTimeQueries = {
+  __typename?: "ProgressOverTimeQueries";
+  /**
+   * Group series: latest snapshot per user+bucket and then
+   * average across users.
+   */
+  groupBkt: ProgressOverTimeSeries;
+  /**
+   * User series: the last snapshot per bucket within the range is taken and
+   * avgLevel is calculated over kcCodes.
+   */
+  userBkt: ProgressOverTimeSeries;
+};
+
+export type ProgressOverTimeQueriesgroupBktArgs = {
+  input: ProgressOverTimeGroupInput;
+};
+
+export type ProgressOverTimeQueriesuserBktArgs = {
+  input: ProgressOverTimeUserInput;
+};
+
+/** Time series (includes buckets with no data such as null) */
+export type ProgressOverTimeSeries = {
+  __typename?: "ProgressOverTimeSeries";
+  points: Array<ProgressOverTimePoint>;
+};
+
+/** Input: individual progress series (BKT) */
+export type ProgressOverTimeUserInput = {
+  /** Temporary bucket (default DAY) */
+  bucket?: ProgressOverTimeBucket;
+  /** Domain identifier */
+  domainId: Scalars["IntID"];
+  /** End date of the range (inclusive) */
+  endDate: Scalars["DateTime"];
+  /** List of valid KC codes */
+  kcCodes: Array<Scalars["String"]>;
+  /** Projects identifier */
+  projectsIds: Array<Scalars["IntID"]>;
+  /** Initial date of the range (inclusive) */
+  startDate: Scalars["DateTime"];
+  /** User identifier */
+  userId: Scalars["IntID"];
+};
+
 /** Project entity */
 export type Project = {
   __typename?: "Project";
@@ -1869,6 +1961,12 @@ export type Query = {
   poll?: Maybe<Poll>;
   /** Get all polls */
   polls: Array<Poll>;
+  /**
+   * Progress series (BKT) added by user and group.
+   *
+   * Returns points per bucket (DAY/WEEK/MONTH).
+   */
+  progressOverTime: ProgressOverTimeQueries;
   /**
    * Get specified project by either "id" or "code".
    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,6 +782,15 @@ importers:
         specifier: workspace:^0.0.1
         version: link:../../db
 
+  packages/services/progressOverTime:
+    dependencies:
+      api-base:
+        specifier: workspace:^0.0.1
+        version: link:../../api-base
+      db:
+        specifier: workspace:^0.0.1
+        version: link:../../db
+
   packages/services/projects:
     dependencies:
       api-base:

--- a/schema.gql
+++ b/schema.gql
@@ -1576,7 +1576,7 @@ enum ProgressOverTimeBucket {
 }
 
 input ProgressOverTimeGroupInput {
-  "Temporary bucket (default DAY)"
+  "Temporal bucket (default DAY)"
   bucket: ProgressOverTimeBucket! = DAY
   "Current user identifier"
   currentUserId: IntID
@@ -1628,7 +1628,7 @@ type ProgressOverTimeSeries {
 
 "Input: individual progress series (BKT)"
 input ProgressOverTimeUserInput {
-  "Temporary bucket (default DAY)"
+  "Temporal bucket (default DAY)"
   bucket: ProgressOverTimeBucket! = DAY
   "Domain identifier"
   domainId: IntID!

--- a/schema.gql
+++ b/schema.gql
@@ -8,35 +8,63 @@ schema {
 User-emitted actions related to system, data mainly used for logging and modeling purposes
 """
 type Action {
-  "Arbitrary numeric amount"
+  """
+  Arbitrary numeric amount
+  """
   amount: Float
-  "Related content"
+  """
+  Related content
+  """
   content: Content
-  "Timestamp of the action, set by the database on row creation"
+  """
+  Timestamp of the action, set by the database on row creation
+  """
   createdAt: DateTime!
-  "Arbitrary string content detail"
+  """
+  Arbitrary string content detail
+  """
   detail: String
-  "Arbitrary JSON object data"
+  """
+  Arbitrary JSON object data
+  """
   extra: JSONObject
-  "Arbitrary hint identifier"
+  """
+  Arbitrary hint identifier
+  """
   hintID: ID
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
-  "Related KCs"
+  """
+  Related KCs
+  """
   kcs: [KC!]!
   "Related poll"
   poll: Poll
-  "Arbitrary numeric result"
+  """
+  Arbitrary numeric result
+  """
   result: Float
-  "Arbitrary step identifier"
+  """
+  Arbitrary step identifier
+  """
   stepID: ID
-  "Timestamp of the action, set by the action emitter"
+  """
+  Timestamp of the action, set by the action emitter
+  """
   timestamp: Timestamp!
-  "Related topic"
+  """
+  Related topic
+  """
   topic: Topic
-  "User that emitted the action"
+  """
+  User that emitted the action
+  """
   user: User
-  "Type of action"
+  """
+  Type of action
+  """
   verb: ActionVerb!
 }
 
@@ -116,25 +144,41 @@ Action Verb
 Main action categorization system
 """
 type ActionVerb {
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
-  "Name of the verb"
+  """
+  Name of the verb
+  """
   name: String!
 }
 
-"Paginated ActionsByContent"
+"""
+Paginated ActionsByContent
+"""
 type ActionsByContentConnection implements Connection {
-  "Nodes of the current page"
+  """
+  Nodes of the current page
+  """
   nodes: [AllActionsByContent!]!
-  "Pagination related information"
+  """
+  Pagination related information
+  """
   pageInfo: PageInfo!
 }
 
-"Paginated ActionsByUser"
+"""
+Paginated ActionsByUser
+"""
 type ActionsByUserConnection implements Connection {
-  "Nodes of the current page"
+  """
+  Nodes of the current page
+  """
   nodes: [AllActionsByUser!]!
-  "Pagination related information"
+  """
+  Pagination related information
+  """
   pageInfo: PageInfo!
 }
 
@@ -147,17 +191,29 @@ type ActionsConnection implements Connection {
 }
 
 input ActionsTopicInput {
-  "End interval for conducting the search."
+  """
+  End interval for conducting the search.
+  """
   endDate: DateTime!
-  "Array of group identifiers that will be used to filter the information corresponding to the users of those groups."
+  """
+  Array of group identifiers that will be used to filter the information corresponding to the users of those groups.
+  """
   groupIds: [Int!]
-  "ID of the project."
+  """
+  ID of the project.
+  """
   projectId: Int!
-  "Start interval for conducting the search."
+  """
+  Start interval for conducting the search.
+  """
   startDate: DateTime!
-  "Array of topic IDs where the search will be performed."
+  """
+  Array of topic IDs where the search will be performed.
+  """
   topicsIds: [Int!]
-  "Array of verbs to be used for action search."
+  """
+  Array of verbs to be used for action search.
+  """
   verbNames: [String!]!
 }
 
@@ -569,30 +625,52 @@ input AdminUsersFilter {
 }
 
 type AllActionsByContent {
-  "Actions performed on the content."
+  """
+  Actions performed on the content.
+  """
   actions: [Action!]!
-  "Unique string identifier"
+  """
+  Unique string identifier
+  """
   code: String!
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
-  "Arbitrary JSON object data"
+  """
+  Arbitrary JSON object data
+  """
   json: JSONObject!
-  "KCs associated with the content"
+  """
+  KCs associated with the content
+  """
   kcs: [KC!]!
 }
 
 type AllActionsByUser {
-  "Actions performed by user"
+  """
+  Actions performed by user
+  """
   actions: [Action!]!
-  "Date of creation"
+  """
+  Date of creation
+  """
   createdAt: DateTime!
-  "Email Address"
+  """
+  Email Address
+  """
   email: String!
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
-  "Model States associated with user"
+  """
+  Model States associated with user
+  """
   modelStates: JSON!
-  "User role"
+  """
+  User role
+  """
   role: String!
 }
 
@@ -748,7 +826,9 @@ type Content {
   createdAt: DateTime!
   "Arbitrary content description"
   description: String!
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
   "Arbitrary JSON object data"
   json: JSONObject
@@ -1151,7 +1231,9 @@ type KC {
   createdAt: DateTime!
   "Domain associated with the KC"
   domain: Domain!
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
   "Human readable identifier"
   label: String!
@@ -1483,6 +1565,85 @@ input PollItemInput {
   tags: [String!]
 }
 
+"Temporal granularity of the bucket."
+enum ProgressOverTimeBucket {
+  "Group by day (UTC)"
+  DAY
+  "Group by month (UTC)"
+  MONTH
+  "Group by week (UTC)"
+  WEEK
+}
+
+input ProgressOverTimeGroupInput {
+  "Temporary bucket (default DAY)"
+  bucket: ProgressOverTimeBucket! = DAY
+  "Current user identifier"
+  currentUserId: IntID
+  "Domain identifier"
+  domainId: IntID!
+  "End date of the range (inclusive)"
+  endDate: DateTime!
+  "Group identifier"
+  groupId: IntID!
+  "List of valid KC codes"
+  kcCodes: [String!]!
+  "Projects identifier"
+  projectsIds: [IntID!]!
+  "Initial date of the range (inclusive)"
+  startDate: DateTime!
+}
+
+"Point in the time series"
+type ProgressOverTimePoint {
+  "Bucket start time (UTC)"
+  at: DateTime!
+  "Average level (BKT) over kcCodes"
+  avgLevel: Float
+  "Number of KCs actually used"
+  nKcsUsed: Int!
+  "Solo group. Users who contributed to the average"
+  nUsers: Int
+  "Latest ModelState.updatedAt used within the bucket"
+  snapshotUpdatedAt: DateTime
+}
+
+type ProgressOverTimeQueries {
+  """
+  Group series: latest snapshot per user+bucket and then
+  average across users.
+  """
+  groupBkt(input: ProgressOverTimeGroupInput!): ProgressOverTimeSeries!
+  """
+  User series: the last snapshot per bucket within the range is taken and
+  avgLevel is calculated over kcCodes.
+  """
+  userBkt(input: ProgressOverTimeUserInput!): ProgressOverTimeSeries!
+}
+
+"Time series (includes buckets with no data such as null)"
+type ProgressOverTimeSeries {
+  points: [ProgressOverTimePoint!]!
+}
+
+"Input: individual progress series (BKT)"
+input ProgressOverTimeUserInput {
+  "Temporary bucket (default DAY)"
+  bucket: ProgressOverTimeBucket! = DAY
+  "Domain identifier"
+  domainId: IntID!
+  "End date of the range (inclusive)"
+  endDate: DateTime!
+  "List of valid KC codes"
+  kcCodes: [String!]!
+  "Projects identifier"
+  projectsIds: [IntID!]!
+  "Initial date of the range (inclusive)"
+  startDate: DateTime!
+  "User identifier"
+  userId: IntID!
+}
+
 "Project entity"
 type Project {
   """
@@ -1737,6 +1898,12 @@ type Query {
   """
   polls(ids: [IntID!]!): [Poll!]!
   """
+  Progress series (BKT) added by user and group.
+
+  Returns points per bucket (DAY/WEEK/MONTH).
+  """
+  progressOverTime: ProgressOverTimeQueries!
+  """
   Get specified project by either "id" or "code".
 
   - If user is not authenticated it will always return NULL.
@@ -1816,7 +1983,9 @@ type Topic {
   content: [Content!]!
   "Date of creation"
   createdAt: DateTime!
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
   "KCs associated with the topic"
   kcs: [KC!]!
@@ -2015,7 +2184,9 @@ type User {
   emailAliases: [String!]
   "Groups associated with the user"
   groups: [Group!]!
-  "Unique numeric identifier"
+  """
+  Unique numeric identifier
+  """
   id: IntID!
   "Date of latest user access"
   lastOnline: DateTime


### PR DESCRIPTION
El servicio progressOverTime calcula y muestra métricas de progreso para los usuarios y grupos asociados a lo largo del tiempo.

Este servicio agrega los estados del modelo bkt (modelStates) y devuelve los datos de progreso agrupados por intervalos de tiempo, esto con el fin de ser ulilizados en gráficos del frontend.

**Cambios**
- Se añadió un nuevo servicio: `packages/services/progressOverTime`
- se implementan las consultas GraphQl `progressOverTime`
- se agrega la lógica de intervalos (day,week,month)
- se actualizó el registro de servicios (`services/list.ts`), además se añadieron los archivos necesarios para la creación del servicio, tal como se describen en la documentación.

**Objetivo:**
El objetivo de la implementación de este nuevo servicio es permitir la visulización del progreso del estudiante a lo largo del tiempo en el dashboard OLM. 

**Testing:**
Las consultas fueron probadas con el cliente Altair GraphQL y se verificó:
-  Agregación correcta de los buckets
- Resultados correctos de usuarios y grupos
- Compatibilidad con el componente del gráfico en el frontend