### PR TITLE
Fix auth, docker-compose filter, and type safety

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       AUTH0_DOMAIN: ${AUTH0_DOMAIN}
       AUTH0_CLIENT: ${AUTH0_CLIENT}
       AUTH0_SECRET: ${AUTH0_SECRET}
-    command: pnpm --filter=service-progressovertime -r start
+    command: pnpm --filter=service-progress-over-time -r start
   gateway:
     restart: always
     image: pabloszx/learner-model-gql

--- a/packages/services/progressOverTime/src/modules/progressOverTime.ts
+++ b/packages/services/progressOverTime/src/modules/progressOverTime.ts
@@ -1,6 +1,5 @@
 import { gql, registerModule } from "../ez";
-import type { EZContext } from "graphql-ez";
-import type { PrismaNS, PrismaClient } from "api-base";
+import type { PrismaNS } from "api-base";
 
 import type {
   Resolvers,
@@ -11,8 +10,6 @@ import type {
 import { addBucket, asBucket, startOfBucket, toKey } from "./utils/bucket";
 import { avgLevelFromBktJson } from "./utils/bktModel";
 import { iterateModelStatesBkt } from "./utils/modelStateIterator";
-
-type Context = EZContext & { prisma: PrismaClient };
 
 export const progressOverTimeModule = registerModule(
   gql`
@@ -45,7 +42,7 @@ export const progressOverTimeModule = registerModule(
       startDate: DateTime!
       "End date of the range (inclusive)"
       endDate: DateTime!
-      "Temporary bucket (default DAY)"
+      "Temporal bucket (default DAY)"
       bucket: ProgressOverTimeBucket! = DAY
       "List of valid KC codes"
       kcCodes: [String!]!
@@ -64,7 +61,7 @@ export const progressOverTimeModule = registerModule(
       startDate: DateTime!
       "End date of the range (inclusive)"
       endDate: DateTime!
-      "Temporary bucket (default DAY)"
+      "Temporal bucket (default DAY)"
       bucket: ProgressOverTimeBucket! = DAY
       "List of valid KC codes"
       kcCodes: [String!]!
@@ -105,7 +102,8 @@ export const progressOverTimeModule = registerModule(
     dirname: import.meta.url,
     resolvers: {
       Query: {
-        progressOverTime() {
+        async progressOverTime(_root, _args, { authorization }) {
+          await authorization.expectUser;
           return {};
         },
       },
@@ -113,7 +111,7 @@ export const progressOverTimeModule = registerModule(
         async userBkt(
           _root,
           { input }: ProgressOverTimeQueriesuserBktArgs,
-          { prisma }: Context
+          { prisma }
         ) {
           const bucket = asBucket(input.bucket);
           const startDate = new Date(input.startDate);
@@ -190,7 +188,7 @@ export const progressOverTimeModule = registerModule(
         async groupBkt(
           _root,
           { input }: ProgressOverTimeQueriesgroupBktArgs,
-          { prisma }: Context
+          { prisma }
         ) {
           const bucket = asBucket(input.bucket);
 
@@ -331,6 +329,6 @@ export const progressOverTimeModule = registerModule(
           return { points };
         },
       },
-    } satisfies Resolvers<Context>,
+    } satisfies Resolvers,
   }
 );

--- a/packages/services/progressOverTime/src/modules/utils/modelStateIterator.ts
+++ b/packages/services/progressOverTime/src/modules/utils/modelStateIterator.ts
@@ -1,4 +1,4 @@
-import type { PrismaNS } from "api-base";
+import type { PrismaNS, PrismaClient } from "api-base";
 
 const BATCH_SIZE = 1000;
 
@@ -10,7 +10,7 @@ export type ModelStateRow = {
 };
 
 export async function iterateModelStatesBkt(
-  prisma: any,
+  prisma: PrismaClient,
   where: PrismaNS.ModelStateWhereInput,
   onRow: (row: ModelStateRow) => void | Promise<void>
 ) {


### PR DESCRIPTION
## Summary

Fixes for #23

- **Add authorization guard**: `progressOverTime` query now requires `authorization.expectUser` — matching the pattern used by `state`, `domain`, `projects`, etc. Without this, unauthenticated users could query any user/group BKT progress.
- **Fix docker-compose filter mismatch**: The filter was `service-progressovertime` but `package.json` names the package `service-progress-over-time`. pnpm filter would silently match nothing.
- **Type `prisma` properly**: Changed `prisma: any` → `prisma: PrismaClient` in `modelStateIterator.ts`.
- **Fix typo**: "Temporary bucket" → "Temporal bucket" in GraphQL schema descriptions (translation artifact from Spanish "temporal").
- **Cleanup**: Removed unused `EZContext` import and custom `Context` type — other services destructure context directly.

## Test plan
- [ ] Verify `progressOverTime` query returns `Forbidden!` when called without a valid auth token
- [ ] Verify `docker-compose up progressovertime` starts the service correctly
- [ ] Run `pnpm tsc --noEmit` to confirm type changes compile